### PR TITLE
Harden controls against emulated MU5250 firmware

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,12 +53,33 @@ Browser ── HTTP/JSON ──► React dashboard (:8080, uhttpd, /data/www)
 | **Home** | live signal, modem mode, throughput, battery, connection, device info and data usage from a single batched poll |
 | **Signal** | per-carrier LTE/NR detail (PCI, ARFCN, RSRP/RSRQ/SINR), network mode, band lock, one-tap cell lock from live cells |
 | **Network** | clients by Wi-Fi/USB-C/Ethernet with link details, per-band Wi-Fi configuration, LAN/DHCP and DNS |
-| **Modem** | APN profiles with carrier presets, data usage + reset day, TTL clamping, SMS (inbox/sent, compose, delete) |
+| **Modem** | manual APN profiles, data usage + reset day, TTL clamping, SMS (inbox/sent, compose, delete) |
 | **System** | thermals, battery health, charge control (stop/resume + limit enforcer), signal/connection loggers, AT console, on-demand process list, device/SIM info, USB mode + powerbank, power actions |
 
 Details: [docs/DASHBOARD.md](docs/DASHBOARD.md) (pages, source layout, local
 demo without hardware) and [docs/AGENT.md](docs/AGENT.md) (endpoint
-reference, 55 paths).
+reference, 57 paths).
+
+## Emulated-device validation
+
+The agent/dashboard contracts and safety-sensitive settings are optimised and
+regression-tested against the stock MU5250 firmware running in QEMU. The
+guarded suite covers optional-service stopping, LAN/DHCP, network modes and
+LTE/NR bands, Wi-Fi 7 EHT bandwidth, unavailable sensor values, manual APNs,
+firmware WMS SMS operations and the read-only AT allowlist. Every mutating
+check restores its original emulated-device state.
+
+Run it after starting the emulator:
+
+```sh
+python3 scripts/test-emulator-fixes.py \
+  --base-url http://127.0.0.1:9090 \
+  --password emu-test-password
+```
+
+QEMU exercises the real firmware userland and UBUS contracts, but cannot
+replace final hardware checks for radios, sensors or the physical modem. See
+[docs/EMULATION.md](docs/EMULATION.md) for the exact fidelity boundaries.
 
 ## Quick start
 

--- a/agent/src/cell.rs
+++ b/agent/src/cell.rs
@@ -1,11 +1,43 @@
 //! Radio selection: network mode, band locking and cell locking.
 //! All of it is driven by the dashboard's Signal → Mode & Locking tab.
 
+use serde::Deserialize;
 use serde_json::{json, Value};
 
 use crate::handlers::AppState;
 use crate::ubus;
 use crate::validate::validate_ubus_input;
+
+pub const LTE_BANDS: &[u8] = &[
+    1, 2, 3, 4, 5, 7, 8, 18, 19, 20, 26, 28, 29, 32, 34, 38, 39, 40, 41, 42, 43, 48, 66, 71,
+];
+pub const NR_BANDS: &[u8] = &[
+    1, 2, 3, 5, 7, 8, 18, 20, 26, 28, 29, 38, 40, 41, 48, 66, 71, 75, 77, 78, 79,
+];
+pub const NETWORK_MODES: &[(&str, &str)] = &[
+    ("WL_AND_5G", "5G / 4G / 3G"),
+    ("LTE_AND_5G", "5G NSA"),
+    ("Only_5G", "5G SA"),
+    ("WCDMA_AND_LTE", "4G / 3G"),
+    ("Only_LTE", "4G only"),
+    ("Only_WCDMA", "3G only"),
+];
+
+pub fn modem_capabilities(_state: &AppState) -> (u16, Value) {
+    let network_modes: Vec<Value> = NETWORK_MODES
+        .iter()
+        .map(|(value, label)| json!({"value": value, "label": label}))
+        .collect();
+    (
+        200,
+        json!({"ok": true, "data": {
+            "network_modes": network_modes,
+            "lte_bands": LTE_BANDS,
+            "nr_sa_bands": NR_BANDS,
+            "nr_nsa_band_lock_supported": false,
+        }}),
+    )
+}
 
 pub fn cell_lock_nr(_state: &AppState, body: &[u8]) -> (u16, Value) {
     let parsed: Value = match serde_json::from_slice(body) {
@@ -55,14 +87,14 @@ pub fn cell_lock_reset(_state: &AppState) -> (u16, Value) {
 }
 
 pub fn cell_band_nr(_state: &AppState, body: &[u8]) -> (u16, Value) {
-    let parsed: Value = match serde_json::from_slice(body) {
+    let parsed: NrBandLock = match serde_json::from_slice(body) {
         Ok(v) => v,
-        Err(_) => return (400, json!({"ok": false, "error": "invalid JSON"})),
+        Err(e) => return (400, json!({"ok": false, "error": format!("invalid NR band selection: {e}")})),
     };
-    if let Err(e) = validate_ubus_input(&parsed) {
+    if let Err(e) = parsed.validate() {
         return (400, json!({"ok": false, "error": e}));
     }
-    let params = parsed.to_string();
+    let params = json!({"nr5g_type": "SA", "nr5g_band": parsed.nr5g_band}).to_string();
     eprintln!("[INFO] [band_nr] ubus call zte_nwinfo_api nwinfo_set_nrbandlock '{params}'");
     match ubus::call("zte_nwinfo_api", "nwinfo_set_nrbandlock", Some(&params)) {
         Ok(data) => {
@@ -77,14 +109,20 @@ pub fn cell_band_nr(_state: &AppState, body: &[u8]) -> (u16, Value) {
 }
 
 pub fn cell_band_lte(_state: &AppState, body: &[u8]) -> (u16, Value) {
-    let parsed: Value = match serde_json::from_slice(body) {
+    let parsed: LteBandLock = match serde_json::from_slice(body) {
         Ok(v) => v,
-        Err(_) => return (400, json!({"ok": false, "error": "invalid JSON"})),
+        Err(e) => return (400, json!({"ok": false, "error": format!("invalid LTE band selection: {e}")})),
     };
-    if let Err(e) = validate_ubus_input(&parsed) {
+    if let Err(e) = parsed.validate() {
         return (400, json!({"ok": false, "error": e}));
     }
-    let params = parsed.to_string();
+    let params = json!({
+        "is_lte_band": "1",
+        "lte_band_mask": parsed.lte_band_mask,
+        "is_gw_band": "0",
+        "gw_band_mask": "0",
+    })
+    .to_string();
     eprintln!("[INFO] [band_lte] ubus call zte_nwinfo_api nwinfo_set_gwl_bandlock '{params}'");
     match ubus::call("zte_nwinfo_api", "nwinfo_set_gwl_bandlock", Some(&params)) {
         Ok(data) => {
@@ -107,19 +145,116 @@ pub fn cell_band_reset(_state: &AppState) -> (u16, Value) {
 
 /// PUT /api/modem/network-mode — preferred RAT (5G SA/NSA, LTE-only, …).
 pub fn modem_network_mode_set(_state: &AppState, body: &[u8]) -> (u16, Value) {
-    let parsed: Value = match serde_json::from_slice(body) {
+    let parsed: NetworkMode = match serde_json::from_slice(body) {
         Ok(v) => v,
-        Err(_) => return (400, json!({"ok": false, "error": "invalid JSON"})),
+        Err(e) => return (400, json!({"ok": false, "error": format!("invalid network mode: {e}")})),
     };
-    if let Err(e) = validate_ubus_input(&parsed) {
-        return (400, json!({"ok": false, "error": e}));
+    if !NETWORK_MODES.iter().any(|(mode, _)| *mode == parsed.net_select) {
+        return (400, json!({"ok": false, "error": "network mode is not supported by U60 Pro firmware"}));
     }
+    let payload = json!({"net_select": parsed.net_select});
     match ubus::call(
         "zte_nwinfo_api",
         "nwinfo_set_netselect",
-        Some(&parsed.to_string()),
+        Some(&payload.to_string()),
     ) {
         Ok(data) => (200, json!({"ok": true, "data": data})),
         Err(e) => (503, json!({"ok": false, "error": e})),
+    }
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct NetworkMode {
+    net_select: String,
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct NrBandLock {
+    nr5g_type: String,
+    nr5g_band: String,
+}
+
+impl NrBandLock {
+    fn validate(&self) -> Result<(), String> {
+        if self.nr5g_type != "SA" {
+            return Err("this firmware only supports NR band locking in SA mode".to_string());
+        }
+        let bands = parse_band_list(&self.nr5g_band)?;
+        if bands.iter().any(|band| !NR_BANDS.contains(band)) {
+            return Err("NR selection contains a band not supported by U60 Pro firmware".to_string());
+        }
+        Ok(())
+    }
+}
+
+fn parse_band_list(value: &str) -> Result<Vec<u8>, String> {
+    let bands: Vec<u8> = value
+        .split(',')
+        .map(str::trim)
+        .map(|band| band.parse::<u8>().map_err(|_| "band list must contain comma-separated numbers".to_string()))
+        .collect::<Result<_, _>>()?;
+    if bands.is_empty() || bands.len() > NR_BANDS.len() {
+        return Err("select at least one band".to_string());
+    }
+    let mut unique = bands.clone();
+    unique.sort_unstable();
+    unique.dedup();
+    if unique.len() != bands.len() {
+        return Err("band list contains duplicates".to_string());
+    }
+    Ok(bands)
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct LteBandLock {
+    is_lte_band: String,
+    lte_band_mask: String,
+    is_gw_band: String,
+    gw_band_mask: String,
+}
+
+impl LteBandLock {
+    fn validate(&self) -> Result<(), String> {
+        if self.is_lte_band != "1" || self.is_gw_band != "0" || self.gw_band_mask != "0" {
+            return Err("LTE band request does not match the firmware contract".to_string());
+        }
+        let mask = self
+            .lte_band_mask
+            .parse::<u128>()
+            .map_err(|_| "lte_band_mask must be a decimal bitmask".to_string())?;
+        let allowed_mask = LTE_BANDS
+            .iter()
+            .fold(0_u128, |allowed, band| allowed | (1_u128 << (band - 1)));
+        if mask == 0 || mask & !allowed_mask != 0 {
+            return Err("LTE mask is empty or contains a band not supported by U60 Pro firmware".to_string());
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn firmware_capability_lists_are_exact() {
+        assert!(LTE_BANDS.contains(&71));
+        assert!(!LTE_BANDS.contains(&12));
+        assert!(NR_BANDS.contains(&79));
+        assert!(NETWORK_MODES.iter().any(|(mode, _)| *mode == "WCDMA_AND_LTE"));
+    }
+
+    #[test]
+    fn band_validation_rejects_unsupported_choices() {
+        assert!(NrBandLock { nr5g_type: "SA".into(), nr5g_band: "1,78".into() }.validate().is_ok());
+        assert!(NrBandLock { nr5g_type: "SA".into(), nr5g_band: "12".into() }.validate().is_err());
+        let valid_mask = ((1_u128 << 0) | (1_u128 << 70)).to_string();
+        assert!(LteBandLock {
+            is_lte_band: "1".into(), lte_band_mask: valid_mask,
+            is_gw_band: "0".into(), gw_band_mask: "0".into(),
+        }.validate().is_ok());
     }
 }

--- a/agent/src/charge_policy.rs
+++ b/agent/src/charge_policy.rs
@@ -211,10 +211,13 @@ impl ChargeLimitEnforcer {
             return;
         }
 
-        let capacity: u8 = fs::read_to_string(SYSFS_CAPACITY)
+        let Some(capacity): Option<u8> = fs::read_to_string(SYSFS_CAPACITY)
             .ok()
             .and_then(|s| s.trim().parse().ok())
-            .unwrap_or(0);
+        else {
+            eprintln!("[charge_policy] capacity unavailable — skipping charger mutation");
+            return;
+        };
 
         if capacity >= limit && !stopped {
             set_charging(false);

--- a/agent/src/device_ext.rs
+++ b/agent/src/device_ext.rs
@@ -37,6 +37,7 @@ pub fn device_thermal_all(_state: &AppState) -> (u16, Value) {
             }
         }
     }
+    data.insert("available".to_string(), json!(!data.is_empty()));
     (200, json!({"ok": true, "data": data}))
 }
 
@@ -49,44 +50,48 @@ pub fn device_battery_detail(_state: &AppState) -> (u16, Value) {
     };
     let read_i64 = |name: &str| -> Option<i64> { read_sysfs(name)?.parse().ok() };
 
-    let capacity = read_i64("capacity").unwrap_or(0);
-    let status = read_sysfs("status").unwrap_or_default();
-    let voltage_uv = read_i64("voltage_now").unwrap_or(0);
-    let voltage_max_uv = read_i64("voltage_max").unwrap_or(0);
-    let voltage_ocv_uv = read_i64("voltage_ocv").unwrap_or(0);
-    let current_ua = read_i64("current_now").unwrap_or(0);
+    let capacity = read_i64("capacity");
+    let status = read_sysfs("status");
+    let voltage_uv = read_i64("voltage_now");
+    let voltage_max_uv = read_i64("voltage_max");
+    let voltage_ocv_uv = read_i64("voltage_ocv");
+    let current_ua = read_i64("current_now");
     // power_now sysfs is unreliable on PM7550B — compute from V * I instead
     let _ = read_i64("power_now"); // ignore sysfs value
-    let temp_tenths = read_i64("temp").unwrap_or(0);
-    let charge_type = read_sysfs("charge_type").unwrap_or_default();
-    let health = read_sysfs("health").unwrap_or_default();
-    let cycle_count = read_i64("cycle_count").unwrap_or(0);
-    let charge_counter_uah = read_i64("charge_counter").unwrap_or(0);
-    let charge_full_uah = read_i64("charge_full").unwrap_or(0);
-    let charge_full_design_uah = read_i64("charge_full_design").unwrap_or(0);
-    let time_to_full = read_i64("time_to_full_avg").unwrap_or(-1);
-    let time_to_empty = read_i64("time_to_empty_avg").unwrap_or(-1);
+    let temp_tenths = read_i64("temp");
+    let charge_type = read_sysfs("charge_type");
+    let health = read_sysfs("health");
+    let cycle_count = read_i64("cycle_count");
+    let charge_counter_uah = read_i64("charge_counter");
+    let charge_full_uah = read_i64("charge_full");
+    let charge_full_design_uah = read_i64("charge_full_design");
+    let time_to_full = read_i64("time_to_full_avg").filter(|value| *value >= 0);
+    let time_to_empty = read_i64("time_to_empty_avg").filter(|value| *value >= 0);
 
     // Compute power from voltage * current (more accurate than sysfs power_now)
-    let power_mw = (voltage_uv as f64 * current_ua as f64 / 1e9) as i64;
+    let power_mw = voltage_uv.zip(current_ua).map(|(voltage, current)| {
+        (voltage as f64 * current as f64 / 1e9) as i64
+    });
+    let available = capacity.is_some() || status.is_some() || voltage_uv.is_some();
 
     (
         200,
         json!({"ok": true, "data": {
+            "available": available,
             "capacity": capacity,
             "status": status,
-            "voltage_mv": voltage_uv / 1000,
-            "voltage_max_mv": voltage_max_uv / 1000,
-            "voltage_ocv_mv": voltage_ocv_uv / 1000,
-            "current_ma": current_ua / 1000,
+            "voltage_mv": voltage_uv.map(|value| value / 1000),
+            "voltage_max_mv": voltage_max_uv.map(|value| value / 1000),
+            "voltage_ocv_mv": voltage_ocv_uv.map(|value| value / 1000),
+            "current_ma": current_ua.map(|value| value / 1000),
             "power_mw": power_mw,
-            "temperature_c": temp_tenths as f64 / 10.0,
+            "temperature_c": temp_tenths.map(|value| value as f64 / 10.0),
             "charge_type": charge_type,
             "health": health,
             "cycle_count": cycle_count,
-            "charge_counter_mah": charge_counter_uah / 1000,
-            "charge_full_mah": charge_full_uah / 1000,
-            "charge_full_design_mah": charge_full_design_uah / 1000,
+            "charge_counter_mah": charge_counter_uah.map(|value| value / 1000),
+            "charge_full_mah": charge_full_uah.map(|value| value / 1000),
+            "charge_full_design_mah": charge_full_design_uah.map(|value| value / 1000),
             "time_to_full_secs": time_to_full,
             "time_to_empty_secs": time_to_empty,
         }}),
@@ -142,23 +147,20 @@ pub fn agent_restart(_state: &AppState) -> (u16, Value) {
 
 /// GET /api/device/charge-control — charge stop state + limit enforcer config
 pub fn charge_control_get(state: &AppState) -> (u16, Value) {
-    let read_sysfs = |path: &str| -> String {
-        fs::read_to_string(path)
-            .unwrap_or_default()
-            .trim()
-            .to_string()
+    let read_sysfs = |path: &str| -> Option<String> {
+        fs::read_to_string(path).ok().map(|value| value.trim().to_string())
     };
 
     let battery_status = read_sysfs("/sys/class/power_supply/battery/status");
-    let capacity: i64 = read_sysfs("/sys/class/power_supply/battery/capacity")
-        .parse()
-        .unwrap_or(0);
+    let capacity: Option<i64> = read_sysfs("/sys/class/power_supply/battery/capacity")
+        .and_then(|value| value.parse().ok());
 
     // Inverted firmware semantics: direct_power_supply_mode "enable" = charging STOPPED
     let charging_stopped = ubus::call("zwrt_bsp.charger", "list", Some("{}"))
         .ok()
-        .and_then(|v| v["direct_power_supply_mode"].as_str().map(|s| s == "enable"))
-        .unwrap_or(false);
+        .and_then(|v| v["direct_power_supply_mode"].as_str().map(|s| s == "enable"));
+    let battery_available = capacity.is_some() || battery_status.is_some();
+    let charger_available = charging_stopped.is_some();
 
     let (limit_enabled, limit_pct, hysteresis, manual_override) = state.charge_limit.get();
 
@@ -167,6 +169,9 @@ pub fn charge_control_get(state: &AppState) -> (u16, Value) {
         json!({
             "ok": true,
             "data": {
+                "available": battery_available || charger_available,
+                "battery_available": battery_available,
+                "charger_available": charger_available,
                 "charging_stopped": charging_stopped,
                 "battery_status": battery_status,
                 "capacity": capacity,
@@ -188,6 +193,13 @@ pub fn charge_control_set(state: &AppState, body: &[u8]) -> (u16, Value) {
 
     // Manual charge stop/resume via ubus (inverted: "enable" = stop, "disable" = start)
     if let Some(stopped) = parsed["charging_stopped"].as_bool() {
+        if ubus::call("zwrt_bsp.charger", "list", Some("{}"))
+            .ok()
+            .and_then(|v| v["direct_power_supply_mode"].as_str().map(str::to_string))
+            .is_none()
+        {
+            return (503, json!({"ok": false, "error": "charger control hardware is unavailable"}));
+        }
         let mode = if stopped { "enable" } else { "disable" };
         let params = format!(r#"{{"direct_power_supply_mode":"{mode}"}}"#);
         if let Err(e) = ubus::call("zwrt_bsp.charger", "set", Some(&params)) {
@@ -205,6 +217,13 @@ pub fn charge_control_set(state: &AppState, body: &[u8]) -> (u16, Value) {
         || parsed.get("charge_limit").is_some()
         || parsed.get("hysteresis").is_some()
     {
+        if fs::read_to_string("/sys/class/power_supply/battery/capacity")
+            .ok()
+            .and_then(|value| value.trim().parse::<u8>().ok())
+            .is_none()
+        {
+            return (503, json!({"ok": false, "error": "battery capacity sensor is unavailable"}));
+        }
         let (cur_enabled, cur_limit, cur_hysteresis, _) = state.charge_limit.get();
         let enabled = parsed["charge_limit_enabled"]
             .as_bool()

--- a/agent/src/handlers.rs
+++ b/agent/src/handlers.rs
@@ -302,8 +302,10 @@ pub fn system_kill_bloat(_state: &AppState, body: &[u8]) -> (u16, Value) {
         );
     };
 
-    let result = system::kill_bloat(pids.as_deref());
-    (200, json!({"ok": true, "data": result}))
+    match system::kill_bloat(pids.as_deref()) {
+        Ok(result) => (200, json!({"ok": true, "data": result})),
+        Err(error) => (503, json!({"ok": false, "error": error})),
+    }
 }
 
 /// GET /api/dashboard — batch endpoint aggregating all dashboard data.

--- a/agent/src/network_ext.rs
+++ b/agent/src/network_ext.rs
@@ -260,7 +260,34 @@ pub fn network_clients(_state: &AppState) -> (u16, Value) {
 
 pub fn network_battery_ubus(_state: &AppState) -> (u16, Value) {
     match ubus::call("zwrt_bsp.battery", "list", Some("{}")) {
-        Ok(data) => (200, json!({"ok": true, "data": data})),
+        Ok(data) => {
+            let number = |key: &str| -> Option<i64> {
+                match data.get(key)? {
+                    Value::Number(value) => value.as_i64(),
+                    Value::String(value) => value.parse().ok(),
+                    _ => None,
+                }
+                .filter(|value| *value >= 0)
+            };
+            let online = number("battery_online").map(|value| value == 1);
+            let low_power = number("battery_low_power").map(|value| value == 1);
+            let using_hw_fg_chip = number("battery_using_hw_fg_chip").map(|value| value == 1);
+            let time_to_full_mins = number("battery_time_to_full");
+            let time_to_empty_mins = number("battery_time_to_empty");
+            let available = online.is_some()
+                || low_power.is_some()
+                || using_hw_fg_chip.is_some()
+                || time_to_full_mins.is_some()
+                || time_to_empty_mins.is_some();
+            (200, json!({"ok": true, "data": {
+                "available": available,
+                "online": online,
+                "low_power": low_power,
+                "using_hw_fg_chip": using_hw_fg_chip,
+                "time_to_full_mins": time_to_full_mins,
+                "time_to_empty_mins": time_to_empty_mins,
+            }}))
+        }
         Err(e) => (503, json!({"ok": false, "error": e})),
     }
 }

--- a/agent/src/router.rs
+++ b/agent/src/router.rs
@@ -1,3 +1,6 @@
+use std::net::Ipv4Addr;
+
+use serde::Deserialize;
 use serde_json::{json, Value};
 
 use crate::handlers::AppState;
@@ -66,48 +69,100 @@ pub fn router_dns_set(_state: &AppState, body: &[u8]) -> (u16, Value) {
 }
 
 pub fn router_lan_get(_state: &AppState) -> (u16, Value) {
-    let ip = ubus::uci_get("network.lan.ipaddr").unwrap_or_default();
-    let mask = ubus::uci_get("network.lan.netmask").unwrap_or_default();
-    let ignore = ubus::uci_get("dhcp.lan.ignore").unwrap_or_default();
-    let start = ubus::uci_get("dhcp.lan.start").unwrap_or_default();
-    let limit = ubus::uci_get("dhcp.lan.limit").unwrap_or_default();
-    let lease = ubus::uci_get("dhcp.lan.leasetime").unwrap_or_default();
-    let end = compute_dhcp_end(&ip, &start, &limit);
-    (
-        200,
-        json!({"ok": true, "data": {
-            "lan_ipaddr": ip, "lan_netmask": mask,
-            "dhcp_enable": if ignore == "1" { "0" } else { "1" },
-            "dhcp_start": start, "dhcp_end": end,
-            "dhcp_lease_time": lease
-        }}),
-    )
+    let read = |key: &str| ubus::uci_get(key).map_err(|e| format!("cannot read {key}: {e}"));
+    let result = (|| {
+        let ipaddr = read("zwrt_router.network.lan_ipaddr")?;
+        let netmask = read("zwrt_router.dhcp.lan_netmask")?;
+        let ignore = read("zwrt_router.dhcp.ignore")?;
+        let dhcp_start = read("zwrt_router.dhcp.zte_start")?;
+        let dhcp_end = read("zwrt_router.dhcp.zte_end")?;
+        let lease_seconds = read("zwrt_router.dhcp.leasetime")?
+            .parse::<u32>()
+            .map_err(|_| "invalid zwrt_router DHCP lease time".to_string())?;
+        Ok::<Value, String>(json!({
+            "ipaddr": ipaddr,
+            "netmask": netmask,
+            "dhcp_enabled": ignore != "1",
+            "dhcp_start": dhcp_start,
+            "dhcp_end": dhcp_end,
+            "lease_seconds": lease_seconds,
+        }))
+    })();
+
+    match result {
+        Ok(data) => (200, json!({"ok": true, "data": data})),
+        Err(error) => (503, json!({"ok": false, "error": error})),
+    }
 }
 
-fn compute_dhcp_end(base_ip: &str, start: &str, limit: &str) -> String {
-    let start_num: u32 = start.parse().unwrap_or(100);
-    let limit_num: u32 = limit.parse().unwrap_or(50);
-    let end_host = start_num + limit_num - 1;
-    // Replace last octet of base IP with end_host
-    if let Some(prefix) = base_ip.rfind('.') {
-        format!("{}.{end_host}", &base_ip[..prefix])
-    } else {
-        format!("192.168.0.{end_host}")
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct LanSettings {
+    ipaddr: String,
+    netmask: String,
+    dhcp_enabled: bool,
+    dhcp_start: String,
+    dhcp_end: String,
+    lease_seconds: u32,
+}
+
+fn validate_lan_settings(settings: &LanSettings) -> Result<(), String> {
+    let ip: Ipv4Addr = settings.ipaddr.parse().map_err(|_| "invalid LAN IPv4 address")?;
+    let mask: Ipv4Addr = settings.netmask.parse().map_err(|_| "invalid IPv4 netmask")?;
+    let start: Ipv4Addr = settings
+        .dhcp_start
+        .parse()
+        .map_err(|_| "invalid DHCP start address")?;
+    let end: Ipv4Addr = settings
+        .dhcp_end
+        .parse()
+        .map_err(|_| "invalid DHCP end address")?;
+
+    let ip = u32::from(ip);
+    let mask = u32::from(mask);
+    let start = u32::from(start);
+    let end = u32::from(end);
+    let inverse = !mask;
+    if inverse & inverse.wrapping_add(1) != 0 || mask.count_ones() < 8 || mask.count_ones() > 30 {
+        return Err("netmask must be contiguous and between /8 and /30".to_string());
     }
+    let network = ip & mask;
+    let broadcast = network | inverse;
+    if start & mask != network || end & mask != network {
+        return Err("DHCP range must be in the LAN subnet".to_string());
+    }
+    if start >= end || start == network || end == broadcast {
+        return Err("DHCP range must contain usable addresses in ascending order".to_string());
+    }
+    if start <= ip && ip <= end {
+        return Err("DHCP range must not include the router address".to_string());
+    }
+    if !(60..=604_800).contains(&settings.lease_seconds) {
+        return Err("lease_seconds must be between 60 and 604800".to_string());
+    }
+    Ok(())
 }
 
 pub fn router_lan_set(_state: &AppState, body: &[u8]) -> (u16, Value) {
-    let parsed: Value = match serde_json::from_slice(body) {
+    let parsed: LanSettings = match serde_json::from_slice(body) {
         Ok(v) => v,
-        Err(_) => return (400, json!({"ok": false, "error": "invalid JSON"})),
+        Err(e) => return (400, json!({"ok": false, "error": format!("invalid LAN settings: {e}")})),
     };
-    if let Err(e) = validate_ubus_input(&parsed) {
+    if let Err(e) = validate_lan_settings(&parsed) {
         return (400, json!({"ok": false, "error": e}));
     }
+    let payload = json!({
+        "ipaddr": parsed.ipaddr,
+        "netmask": parsed.netmask,
+        "ignore": if parsed.dhcp_enabled { 0 } else { 1 },
+        "zte_start": parsed.dhcp_start,
+        "zte_end": parsed.dhcp_end,
+        "leasetime": parsed.lease_seconds.to_string(),
+    });
     match ubus::call(
         "zwrt_router.api",
         "router_set_lan_para",
-        Some(&parsed.to_string()),
+        Some(&payload.to_string()),
     ) {
         Ok(data) => (200, json!({"ok": true, "data": data})),
         Err(e) => (503, json!({"ok": false, "error": e})),
@@ -122,14 +177,14 @@ pub fn router_apn_mode_get(_state: &AppState) -> (u16, Value) {
 }
 
 pub fn router_apn_mode_set(_state: &AppState, body: &[u8]) -> (u16, Value) {
-    let parsed: Value = match serde_json::from_slice(body) {
+    let parsed: ApnMode = match serde_json::from_slice(body) {
         Ok(v) => v,
-        Err(_) => return (400, json!({"ok": false, "error": "invalid JSON"})),
+        Err(e) => return (400, json!({"ok": false, "error": format!("invalid APN mode: {e}")})),
     };
-    if let Err(e) = validate_ubus_input(&parsed) {
-        return (400, json!({"ok": false, "error": e}));
+    if parsed.apn_mode > 1 {
+        return (400, json!({"ok": false, "error": "apn_mode must be 0 (automatic) or 1 (manual)"}));
     }
-    match ubus::call("zwrt_apn_object", "set_apn_mode", Some(&parsed.to_string())) {
+    match ubus::call("zwrt_apn_object", "set_apn_mode", Some(&json!({"apn_mode": parsed.apn_mode}).to_string())) {
         Ok(data) => (200, json!({"ok": true, "data": data})),
         Err(e) => (503, json!({"ok": false, "error": e})),
     }
@@ -143,31 +198,47 @@ pub fn router_apn_profiles_get(_state: &AppState) -> (u16, Value) {
 }
 
 pub fn router_apn_profiles_add(_state: &AppState, body: &[u8]) -> (u16, Value) {
-    let parsed: Value = match serde_json::from_slice(body) {
+    let parsed: ManualApn = match serde_json::from_slice(body) {
         Ok(v) => v,
-        Err(_) => return (400, json!({"ok": false, "error": "invalid JSON"})),
+        Err(e) => return (400, json!({"ok": false, "error": format!("invalid APN profile: {e}")})),
     };
-    if let Err(e) = validate_ubus_input(&parsed) {
+    if let Err(e) = parsed.validate() {
         return (400, json!({"ok": false, "error": e}));
     }
-    match ubus::call("zwrt_apn_object", "add_manu_apn", Some(&parsed.to_string())) {
+    let payload = json!({
+        "profilename": parsed.profilename,
+        "wanapn": parsed.wanapn,
+        "username": parsed.username,
+        "password": parsed.password,
+        "pdpType": parsed.pdp_type,
+        "pppAuthMode": parsed.ppp_auth_mode,
+    });
+    match ubus::call("zwrt_apn_object", "add_manu_apn", Some(&payload.to_string())) {
         Ok(data) => (200, json!({"ok": true, "data": data})),
         Err(e) => (503, json!({"ok": false, "error": e})),
     }
 }
 
 pub fn router_apn_profiles_delete(_state: &AppState, body: &[u8]) -> (u16, Value) {
-    let parsed: Value = match serde_json::from_slice(body) {
+    let parsed: ApnProfileId = match serde_json::from_slice(body) {
         Ok(v) => v,
-        Err(_) => return (400, json!({"ok": false, "error": "invalid JSON"})),
+        Err(e) => return (400, json!({"ok": false, "error": format!("invalid profile id: {e}")})),
     };
-    if let Err(e) = validate_ubus_input(&parsed) {
+    if let Err(e) = parsed.validate() {
         return (400, json!({"ok": false, "error": e}));
     }
+    match ubus::call("zwrt_apn_object", "get_manu_apn_list", Some("{}")) {
+        Ok(data) if apn_profile_is_active(&data, &parsed.profile_id) => {
+            return (409, json!({"ok": false, "error": "cannot delete the active APN profile"}));
+        }
+        Ok(_) => {}
+        Err(e) => return (503, json!({"ok": false, "error": format!("cannot verify active APN profile: {e}")})),
+    }
+    let payload = json!({"profileId": parsed.profile_id});
     match ubus::call(
         "zwrt_apn_object",
         "delete_manu_apn",
-        Some(&parsed.to_string()),
+        Some(&payload.to_string()),
     ) {
         Ok(data) => (200, json!({"ok": true, "data": data})),
         Err(e) => (503, json!({"ok": false, "error": e})),
@@ -175,19 +246,178 @@ pub fn router_apn_profiles_delete(_state: &AppState, body: &[u8]) -> (u16, Value
 }
 
 pub fn router_apn_profiles_activate(_state: &AppState, body: &[u8]) -> (u16, Value) {
-    let parsed: Value = match serde_json::from_slice(body) {
+    let parsed: ApnProfileId = match serde_json::from_slice(body) {
         Ok(v) => v,
-        Err(_) => return (400, json!({"ok": false, "error": "invalid JSON"})),
+        Err(e) => return (400, json!({"ok": false, "error": format!("invalid profile id: {e}")})),
     };
-    if let Err(e) = validate_ubus_input(&parsed) {
+    if let Err(e) = parsed.validate() {
         return (400, json!({"ok": false, "error": e}));
     }
+    let current_mode = ubus::call("zwrt_apn_object", "get_apn_mode", Some("{}"))
+        .ok()
+        .and_then(|v| v.get("apn_mode").and_then(Value::as_u64));
+    if let Err(e) = ubus::call("zwrt_apn_object", "set_apn_mode", Some(r#"{"apn_mode":1}"#)) {
+        return (503, json!({"ok": false, "error": format!("cannot enable manual APN mode: {e}")}));
+    }
+    let payload = json!({"profileId": parsed.profile_id});
     match ubus::call(
         "zwrt_apn_object",
         "enable_manu_apn_id",
-        Some(&parsed.to_string()),
+        Some(&payload.to_string()),
     ) {
         Ok(data) => (200, json!({"ok": true, "data": data})),
-        Err(e) => (503, json!({"ok": false, "error": e})),
+        Err(e) => {
+            if current_mode == Some(0) {
+                let _ = ubus::call("zwrt_apn_object", "set_apn_mode", Some(r#"{"apn_mode":0}"#));
+            }
+            (503, json!({"ok": false, "error": e}))
+        }
+    }
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct ApnMode {
+    apn_mode: u8,
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields, rename_all = "camelCase")]
+struct ManualApn {
+    profilename: String,
+    wanapn: String,
+    #[serde(default)]
+    username: String,
+    #[serde(default)]
+    password: String,
+    pdp_type: u8,
+    ppp_auth_mode: u8,
+}
+
+impl ManualApn {
+    fn validate(&self) -> Result<(), String> {
+        validate_apn_text("profilename", &self.profilename, 64, false)?;
+        validate_apn_text("wanapn", &self.wanapn, 100, false)?;
+        validate_apn_text("username", &self.username, 128, true)?;
+        validate_apn_text("password", &self.password, 128, true)?;
+        if !(1..=3).contains(&self.pdp_type) {
+            return Err("pdpType must be 1 (IPv4), 2 (IPv6), or 3 (IPv4v6)".to_string());
+        }
+        if self.ppp_auth_mode > 3 {
+            return Err("pppAuthMode must be between 0 and 3".to_string());
+        }
+        if self.ppp_auth_mode == 0 && (!self.username.is_empty() || !self.password.is_empty()) {
+            return Err("credentials require PAP, CHAP, or PAP/CHAP authentication".to_string());
+        }
+        Ok(())
+    }
+}
+
+fn validate_apn_text(field: &str, value: &str, max: usize, allow_empty: bool) -> Result<(), String> {
+    if !allow_empty && value.trim().is_empty() {
+        return Err(format!("{field} is required"));
+    }
+    if value.len() > max || value.chars().any(char::is_control) {
+        return Err(format!("{field} is invalid or longer than {max} characters"));
+    }
+    Ok(())
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields, rename_all = "camelCase")]
+struct ApnProfileId {
+    profile_id: String,
+}
+
+impl ApnProfileId {
+    fn validate(&self) -> Result<(), String> {
+        if self.profile_id.is_empty()
+            || self.profile_id.len() > 32
+            || !self
+                .profile_id
+                .bytes()
+                .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'_' | b'-'))
+        {
+            return Err("profileId must be a firmware profile identifier".to_string());
+        }
+        Ok(())
+    }
+}
+
+fn apn_profile_is_active(data: &Value, profile_id: &str) -> bool {
+    data.get("apnListArray")
+        .and_then(Value::as_array)
+        .into_iter()
+        .flatten()
+        .any(|profile| {
+            let id_matches = profile
+                .get("profileId")
+                .map(|id| match id {
+                    Value::String(id) => id == profile_id,
+                    Value::Number(id) => id.to_string() == profile_id,
+                    _ => false,
+                })
+                .unwrap_or(false);
+            let enabled = profile.get("isEnable").is_some_and(|enabled| match enabled {
+                Value::Bool(enabled) => *enabled,
+                Value::Number(enabled) => enabled.as_u64() == Some(1),
+                Value::String(enabled) => enabled == "1" || enabled.eq_ignore_ascii_case("true"),
+                _ => false,
+            });
+            id_matches && enabled
+        })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn valid_lan() -> LanSettings {
+        LanSettings {
+            ipaddr: "192.168.0.1".into(),
+            netmask: "255.255.255.0".into(),
+            dhcp_enabled: true,
+            dhcp_start: "192.168.0.2".into(),
+            dhcp_end: "192.168.0.253".into(),
+            lease_seconds: 86_400,
+        }
+    }
+
+    #[test]
+    fn lan_validation_matches_stock_full_address_contract() {
+        assert!(validate_lan_settings(&valid_lan()).is_ok());
+        let mut invalid = valid_lan();
+        invalid.dhcp_start = "192.168.1.2".into();
+        assert!(validate_lan_settings(&invalid).is_err());
+        let mut includes_router = valid_lan();
+        includes_router.dhcp_start = "192.168.0.1".into();
+        assert!(validate_lan_settings(&includes_router).is_err());
+    }
+
+    #[test]
+    fn apn_validation_rejects_unknown_firmware_values() {
+        let profile = ManualApn {
+            profilename: "Test".into(),
+            wanapn: "internet".into(),
+            username: String::new(),
+            password: String::new(),
+            pdp_type: 3,
+            ppp_auth_mode: 0,
+        };
+        assert!(profile.validate().is_ok());
+        let invalid = ManualApn { pdp_type: 4, ..profile };
+        assert!(invalid.validate().is_err());
+    }
+
+    #[test]
+    fn active_apn_profiles_are_detected_across_firmware_types() {
+        let data = json!({"apnListArray": [
+            {"profileId": 4, "isEnable": "1"},
+            {"profileId": "5", "isEnable": false}
+        ]});
+        assert!(apn_profile_is_active(&data, "4"));
+        assert!(!apn_profile_is_active(&data, "5"));
+        assert!(ApnProfileId { profile_id: "manu1".into() }.validate().is_ok());
+        assert!(ApnProfileId { profile_id: "../../etc".into() }.validate().is_err());
     }
 }

--- a/agent/src/server.rs
+++ b/agent/src/server.rs
@@ -83,7 +83,11 @@ pub fn start(bind: &str, threads: usize, state: Arc<AppState>) {
     }
 }
 
-const DESTRUCTIVE_PATHS: &[&str] = &["/api/device/reboot", "/api/device/shutdown"];
+const DESTRUCTIVE_PATHS: &[&str] = &[
+    "/api/device/reboot",
+    "/api/device/shutdown",
+    "/api/system/kill-bloat",
+];
 
 fn cors_headers(origin: Option<&str>) -> Vec<Header> {
     let allowed = origin
@@ -256,8 +260,10 @@ pub fn route(
         (&Method::Put, "/api/data-usage/reset-day") => {
             handlers::data_usage_reset_day_set(state, body)
         }
+        (&Method::Get, "/api/modem/capabilities") => cell::modem_capabilities(state),
         (&Method::Put, "/api/modem/network-mode") => cell::modem_network_mode_set(state, body),
         // SMS
+        (&Method::Get, "/api/sms/capabilities") => sms::sms_capabilities(state),
         (&Method::Post, "/api/sms/list") => sms::sms_list(state, body),
         (&Method::Post, "/api/sms/send") => sms::sms_send(state, body),
         (&Method::Post, "/api/sms/delete") => sms::sms_delete(state, body),
@@ -353,14 +359,16 @@ const AT_BLOCKED_PREFIXES: &[&str] = &[
     "AT+CGACT=",
 ];
 
-const AT_ALLOWED_PREFIXES: &[&str] = &[
+const AT_ALLOWED_EXACT: &[&str] = &[
+    "AT",
     "ATI",
     "AT+CSQ",
-    "AT+COPS",
+    "AT+COPS?",
+    "AT+COPS=?",
     "AT+CGDCONT?",
-    "AT+CREG",
-    "AT+CGREG",
-    "AT+CEREG",
+    "AT+CREG?",
+    "AT+CGREG?",
+    "AT+CEREG?",
     "AT+CGPADDR",
     "AT+CGACT?",
     "AT+CLAC",
@@ -368,17 +376,14 @@ const AT_ALLOWED_PREFIXES: &[&str] = &[
     "AT+CGMI",
     "AT+CGMM",
     "AT+CGMR",
-    "AT+QENG",
+    "AT+QENG=\"SERVINGCELL\"",
     "AT+QNWINFO",
     "AT+QRSRP",
     "AT+QRSRQ",
     "AT+QINISTAT",
     "AT+QSPN",
     "AT+QCIDINCOMING",
-    "AT+CGDCONT?",
     "AT+CGCONTRDP",
-    "AT+CGPADDR",
-    "AT",
 ];
 
 fn is_at_command_allowed(cmd: &str) -> bool {
@@ -391,12 +396,7 @@ fn is_at_command_allowed(cmd: &str) -> bool {
             return false;
         }
     }
-    for prefix in AT_ALLOWED_PREFIXES {
-        if upper.starts_with(prefix) {
-            return true;
-        }
-    }
-    false
+    AT_ALLOWED_EXACT.contains(&upper.as_str())
 }
 
 /// GET /api/at/port — report the detected AT serial port (if any)
@@ -551,4 +551,20 @@ fn respond(request: Request, status: u16, body: Value, origin: Option<&str>) {
         response = response.with_header(h);
     }
     let _ = request.respond(response);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::is_at_command_allowed;
+
+    #[test]
+    fn at_allowlist_is_exact_and_read_only() {
+        assert!(is_at_command_allowed("AT"));
+        assert!(is_at_command_allowed("at+csq"));
+        assert!(is_at_command_allowed("AT+QENG=\"servingcell\""));
+        assert!(!is_at_command_allowed("AT+CSQ=1"));
+        assert!(!is_at_command_allowed("AT+FOO"));
+        assert!(!is_at_command_allowed("AT+CFUN=1"));
+        assert!(!is_at_command_allowed("AT^RESET"));
+    }
 }

--- a/agent/src/sms.rs
+++ b/agent/src/sms.rs
@@ -1,185 +1,273 @@
 use std::process::Command;
+use std::thread;
+use std::time::Duration;
 
+use serde::Deserialize;
 use serde_json::{json, Value};
 
 use crate::handlers::AppState;
 use crate::ubus;
-use crate::validate::validate_ubus_input;
 
-const SMS_DB_PATH: &str = "/etc_rw/ztembb/ztesms/sms_db/sms.db";
+const STOCK_WMS_OBJECT: &str = "zwrt_wms";
+const SMS_MEMORY_STORE: u8 = 1;
+const SMS_ALL_TAGS: u8 = 10;
+
+fn wms_object() -> String {
+    std::env::var("ZTE_AGENT_WMS_OBJECT").unwrap_or_else(|_| STOCK_WMS_OBJECT.to_string())
+}
+
+fn value_i64(value: Option<&Value>) -> Option<i64> {
+    match value? {
+        Value::Number(value) => value.as_i64(),
+        Value::String(value) => value.parse().ok(),
+        _ => None,
+    }
+}
+
+fn command_status(object: &str, command: u8) -> Result<i64, String> {
+    let payload = json!({"sms_cmd": command}).to_string();
+    let response = ubus::call(object, "zwrt_wms_get_cmd_status", Some(&payload))?;
+    value_i64(response.get("sms_cmd_status_result"))
+        .ok_or_else(|| "WMS returned no command status".to_string())
+}
+
+pub fn sms_capabilities(_state: &AppState) -> (u16, Value) {
+    let object = wms_object();
+    match command_status(&object, 1) {
+        Ok(3) => (200, json!({"ok": true, "data": {
+            "available": true,
+            "ready": true,
+            "object": object,
+            "storage": "native",
+        }})),
+        Ok(status) => (200, json!({"ok": true, "data": {
+            "available": false,
+            "ready": false,
+            "object": object,
+            "reason": format!("WMS is not ready (status {status})"),
+        }})),
+        Err(error) => (200, json!({"ok": true, "data": {
+            "available": false,
+            "ready": false,
+            "object": object,
+            "reason": error,
+        }})),
+    }
+}
+
+#[derive(Deserialize)]
+#[serde(default, deny_unknown_fields)]
+struct SmsListRequest {
+    page: u16,
+    per_page: u16,
+}
+
+impl Default for SmsListRequest {
+    fn default() -> Self {
+        Self { page: 0, per_page: 500 }
+    }
+}
 
 pub fn sms_list(_state: &AppState, body: &[u8]) -> (u16, Value) {
-    let parsed: Value = match serde_json::from_slice(body) {
-        Ok(v) => v,
-        Err(_) => return (400, json!({"ok": false, "error": "invalid JSON"})),
+    let request: SmsListRequest = if body.is_empty() {
+        SmsListRequest::default()
+    } else {
+        match serde_json::from_slice(body) {
+            Ok(value) => value,
+            Err(error) => return (400, json!({"ok": false, "error": format!("invalid SMS list request: {error}")})),
+        }
     };
-    if let Err(e) = validate_ubus_input(&parsed) {
-        return (400, json!({"ok": false, "error": e}));
+    if request.per_page == 0 || request.per_page > 500 {
+        return (400, json!({"ok": false, "error": "per_page must be between 1 and 500"}));
     }
-    match ubus::call(
-        "zwrt_wms",
-        "zte_libwms_get_sms_data",
-        Some(&parsed.to_string()),
-    ) {
+    let payload = json!({
+        "page": request.page,
+        "data_per_page": request.per_page,
+        "mem_store": SMS_MEMORY_STORE,
+        "tags": SMS_ALL_TAGS,
+        "order_by": "order by id desc",
+    });
+    match ubus::call(&wms_object(), "zte_libwms_get_sms_data", Some(&payload.to_string())) {
         Ok(data) => (200, json!({"ok": true, "data": data})),
-        Err(e) => (503, json!({"ok": false, "error": e})),
+        Err(error) => (503, json!({"ok": false, "error": error})),
     }
 }
 
-pub fn sms_send(_state: &AppState, body: &[u8]) -> (u16, Value) {
-    let parsed: Value = match serde_json::from_slice(body) {
-        Ok(v) => v,
-        Err(_) => return (400, json!({"ok": false, "error": "invalid JSON"})),
-    };
-    if let Err(e) = validate_ubus_input(&parsed) {
-        return (400, json!({"ok": false, "error": e}));
-    }
-    match ubus::call("zwrt_wms", "zte_libwms_send_sms", Some(&parsed.to_string())) {
-        Ok(data) => (200, json!({"ok": true, "data": data})),
-        Err(e) => (503, json!({"ok": false, "error": e})),
-    }
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct SmsSendRequest {
+    number: String,
+    message: String,
 }
 
-/// Delete one or more SMS by id.
-///
-/// Body shape (legacy ZTE format): `{"id": "3681;3682;"}` — semicolon-joined ids with trailing `;`.
-///
-/// Firmware bug: `zwrt_wms_delete_sms` works for NV-stored messages but silently returns
-/// `{"result": 3}` without deleting SIM-stored rows. The daemon's listing reads from
-/// `/etc_rw/ztembb/ztesms/sms_db/sms.db`, so we fall back to a direct SQLite DELETE for any
-/// id that survived the ubus call.
-pub fn sms_delete(_state: &AppState, body: &[u8]) -> (u16, Value) {
-    let parsed: Value = match serde_json::from_slice(body) {
-        Ok(v) => v,
-        Err(_) => return (400, json!({"ok": false, "error": "invalid JSON"})),
-    };
-    if let Err(e) = validate_ubus_input(&parsed) {
-        return (400, json!({"ok": false, "error": e}));
-    }
-
-    let ids = match parse_ids(parsed.get("id")) {
-        Ok(v) if !v.is_empty() => v,
-        Ok(_) => return (400, json!({"ok": false, "error": "no ids in 'id' field"})),
-        Err(e) => return (400, json!({"ok": false, "error": e})),
-    };
-
-    let ubus_result = ubus::call("zwrt_wms", "zwrt_wms_delete_sms", Some(&parsed.to_string()));
-
-    let survivors = match db_filter_existing(&ids) {
-        Ok(v) => v,
-        Err(e) => {
-            return match ubus_result {
-                Ok(data) => (
-                    200,
-                    json!({"ok": true, "data": data, "warning": format!("db check skipped: {e}")}),
-                ),
-                Err(ubus_err) => (
-                    503,
-                    json!({"ok": false, "error": format!("ubus: {ubus_err}; db: {e}")}),
-                ),
-            };
-        }
-    };
-
-    if survivors.is_empty() {
-        return (
-            200,
-            json!({"ok": true, "data": ubus_result.unwrap_or(Value::Null), "deleted_via": "ubus"}),
-        );
-    }
-
-    match db_delete_ids(&survivors) {
-        Ok(()) => (
-            200,
-            json!({"ok": true, "deleted_via": "sqlite", "ids": survivors}),
-        ),
-        Err(e) => (
-            503,
-            json!({"ok": false, "error": format!("sqlite delete failed: {e}")}),
-        ),
-    }
-}
-
-/// Parse the legacy ZTE id format (semicolon-joined with trailing `;`).
-fn parse_ids(field: Option<&Value>) -> Result<Vec<i64>, String> {
-    let raw = field.ok_or_else(|| "missing 'id' field".to_string())?;
-    let s = raw.as_str().ok_or_else(|| "'id' must be a string".to_string())?;
-    let mut out = Vec::new();
-    for part in s.split(';') {
-        let p = part.trim();
-        if p.is_empty() {
-            continue;
-        }
-        let n: i64 = p
-            .parse()
-            .map_err(|_| format!("invalid id '{p}' (must be integer)"))?;
-        out.push(n);
-    }
-    Ok(out)
-}
-
-/// Return the subset of `ids` still present in the WMS sms table.
-fn db_filter_existing(ids: &[i64]) -> Result<Vec<i64>, String> {
-    if ids.is_empty() {
-        return Ok(Vec::new());
-    }
-    let in_clause = ids
-        .iter()
-        .map(|n| n.to_string())
-        .collect::<Vec<_>>()
-        .join(",");
-    let sql = format!("SELECT id FROM sms WHERE id IN ({in_clause});");
-    let output = Command::new("/usr/bin/sqlite3")
-        .args(["-cmd", ".timeout 2000", "-readonly", SMS_DB_PATH, &sql])
-        .output()
-        .map_err(|e| format!("spawn sqlite3: {e}"))?;
-    if !output.status.success() {
-        return Err(String::from_utf8_lossy(&output.stderr).trim().to_string());
-    }
-    let mut out = Vec::new();
-    for line in String::from_utf8_lossy(&output.stdout).lines() {
-        let l = line.trim();
-        if l.is_empty() {
-            continue;
-        }
-        if let Ok(n) = l.parse::<i64>() {
-            out.push(n);
-        }
-    }
-    Ok(out)
-}
-
-/// Direct DELETE bypassing the broken ubus path for SIM-stored rows.
-fn db_delete_ids(ids: &[i64]) -> Result<(), String> {
-    if ids.is_empty() {
-        return Ok(());
-    }
-    let in_clause = ids
-        .iter()
-        .map(|n| n.to_string())
-        .collect::<Vec<_>>()
-        .join(",");
-    let sql = format!("DELETE FROM sms WHERE id IN ({in_clause});");
-    let output = Command::new("/usr/bin/sqlite3")
-        .args(["-cmd", ".timeout 2000", SMS_DB_PATH, &sql])
-        .output()
-        .map_err(|e| format!("spawn sqlite3: {e}"))?;
-    if !output.status.success() {
-        return Err(String::from_utf8_lossy(&output.stderr).trim().to_string());
+fn validate_recipient(number: &str) -> Result<(), String> {
+    if number.is_empty()
+        || number.len() > 32
+        || !number
+            .bytes()
+            .all(|byte| byte.is_ascii_digit() || matches!(byte, b'+' | b'*' | b'#'))
+    {
+        return Err("recipient must contain only digits, +, * or # and be at most 32 characters".to_string());
     }
     Ok(())
 }
 
-pub fn sms_mark_read(_state: &AppState, body: &[u8]) -> (u16, Value) {
-    let parsed: Value = match serde_json::from_slice(body) {
-        Ok(v) => v,
-        Err(_) => return (400, json!({"ok": false, "error": "invalid JSON"})),
-    };
-    if let Err(e) = validate_ubus_input(&parsed) {
-        return (400, json!({"ok": false, "error": e}));
+fn encode_message(message: &str) -> String {
+    message.chars().map(|character| format!("{:04X}", character as u32)).collect()
+}
+
+fn encode_type(message: &str) -> &'static str {
+    // A conservative subset of GSM 03.38. Anything else is sent as Unicode,
+    // which is also what the stock UI does when a character is absent from
+    // its GSM7 table.
+    const GSM7: &str = "@£$¥èéùìòÇ\nØø\rÅåΔ_ΦΓΛΩΠΨΣΘΞ ÆæßÉ !\"#¤%&'()*+,-./0123456789:;<=>?¡ABCDEFGHIJKLMNOPQRSTUVWXYZÄÖÑÜ§¿abcdefghijklmnopqrstuvwxyzäöñüà^{}\\[~]|€";
+    if message.chars().all(|character| GSM7.contains(character)) {
+        "GSM7_default"
+    } else {
+        "UNICODE"
     }
-    match ubus::call("zwrt_wms", "zwrt_wms_modify_tag", Some(&parsed.to_string())) {
+}
+
+fn sms_timestamp() -> Result<String, String> {
+    let output = Command::new("date")
+        .arg("+%y;%m;%d;%H;%M;%S;%z")
+        .output()
+        .map_err(|error| format!("date exec: {error}"))?;
+    if !output.status.success() {
+        return Err("cannot generate SMS timestamp".to_string());
+    }
+    let raw = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    let Some((prefix, zone)) = raw.rsplit_once(';') else {
+        return Err("invalid local timestamp".to_string());
+    };
+    if zone.len() != 5 {
+        return Err("invalid timezone offset".to_string());
+    }
+    let sign = &zone[..1];
+    let hours: f64 = zone[1..3].parse::<f64>().map_err(|_| "invalid timezone hours")?;
+    let minutes: f64 = zone[3..5].parse::<f64>().map_err(|_| "invalid timezone minutes")?;
+    let offset = hours + minutes / 60.0;
+    let offset = if offset.fract() == 0.0 { format!("{sign}{}", offset as i32) } else { format!("{sign}{offset}") };
+    Ok(format!("{prefix};{offset}"))
+}
+
+fn wait_for_command(object: &str, command: u8) -> Result<(), String> {
+    for _ in 0..20 {
+        thread::sleep(Duration::from_millis(500));
+        match command_status(object, command)? {
+            3 => return Ok(()),
+            2 => return Err(format!("WMS command {command} failed")),
+            _ => {}
+        }
+    }
+    Err(format!("WMS command {command} timed out"))
+}
+
+pub fn sms_send(_state: &AppState, body: &[u8]) -> (u16, Value) {
+    let request: SmsSendRequest = match serde_json::from_slice(body) {
+        Ok(value) => value,
+        Err(error) => return (400, json!({"ok": false, "error": format!("invalid SMS: {error}")})),
+    };
+    if let Err(error) = validate_recipient(&request.number) {
+        return (400, json!({"ok": false, "error": error}));
+    }
+    let length = request.message.chars().count();
+    if length == 0 || length > 160 || request.message.chars().any(|character| character == '\0') {
+        return (400, json!({"ok": false, "error": "message must contain 1 to 160 characters"}));
+    }
+    let payload = json!({
+        "number": request.number,
+        "sms_time": match sms_timestamp() {
+            Ok(value) => value,
+            Err(error) => return (500, json!({"ok": false, "error": error})),
+        },
+        "message_body": encode_message(&request.message),
+        "id": "-1",
+        "encode_type": encode_type(&request.message),
+    });
+    let object = wms_object();
+    if let Err(error) = ubus::call(&object, "zte_libwms_send_sms", Some(&payload.to_string())) {
+        return (503, json!({"ok": false, "error": error}));
+    }
+    match wait_for_command(&object, 4) {
+        Ok(()) => (200, json!({"ok": true, "data": {"result": "success"}})),
+        Err(error) => (503, json!({"ok": false, "error": error})),
+    }
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct SmsIds {
+    ids: Vec<u64>,
+}
+
+fn ids_payload(ids: &[u64]) -> Result<String, String> {
+    if ids.is_empty() || ids.len() > 100 || ids.contains(&0) {
+        return Err("ids must contain between 1 and 100 positive message identifiers".to_string());
+    }
+    Ok(ids.iter().map(|id| format!("{id};")).collect())
+}
+
+pub fn sms_delete(_state: &AppState, body: &[u8]) -> (u16, Value) {
+    let request: SmsIds = match serde_json::from_slice(body) {
+        Ok(value) => value,
+        Err(error) => return (400, json!({"ok": false, "error": format!("invalid SMS ids: {error}")})),
+    };
+    let ids = match ids_payload(&request.ids) {
+        Ok(ids) => ids,
+        Err(error) => return (400, json!({"ok": false, "error": error})),
+    };
+    let object = wms_object();
+    if let Err(error) = ubus::call(&object, "zwrt_wms_delete_sms", Some(&json!({"id": ids}).to_string())) {
+        return (503, json!({"ok": false, "error": error}));
+    }
+    match wait_for_command(&object, 6) {
+        Ok(()) => (200, json!({"ok": true, "data": {"result": "success"}})),
+        Err(error) => (503, json!({"ok": false, "error": error})),
+    }
+}
+
+pub fn sms_mark_read(_state: &AppState, body: &[u8]) -> (u16, Value) {
+    let request: SmsIds = match serde_json::from_slice(body) {
+        Ok(value) => value,
+        Err(error) => return (400, json!({"ok": false, "error": format!("invalid SMS ids: {error}")})),
+    };
+    let ids = match ids_payload(&request.ids) {
+        Ok(ids) => ids,
+        Err(error) => return (400, json!({"ok": false, "error": error})),
+    };
+    match ubus::call(
+        &wms_object(),
+        "zwrt_wms_modify_tag",
+        Some(&json!({"id": ids, "tag": 0}).to_string()),
+    ) {
         Ok(data) => (200, json!({"ok": true, "data": data})),
-        Err(e) => (503, json!({"ok": false, "error": e})),
+        Err(error) => (503, json!({"ok": false, "error": error})),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn stock_ucs_encoding_handles_ascii_and_astral_unicode() {
+        assert_eq!(encode_message("Hi"), "00480069");
+        assert_eq!(encode_message("😀"), "1F600");
+        assert_eq!(encode_type("Hello"), "GSM7_default");
+        assert_eq!(encode_type("你好"), "UNICODE");
+    }
+
+    #[test]
+    fn legacy_id_payload_is_generated_only_from_typed_ids() {
+        assert_eq!(ids_payload(&[12, 34]).unwrap(), "12;34;");
+        assert!(ids_payload(&[]).is_err());
+        assert!(ids_payload(&[0]).is_err());
+    }
+
+    #[test]
+    fn recipient_validation_blocks_arbitrary_wms_input() {
+        assert!(validate_recipient("+61400000000").is_ok());
+        assert!(validate_recipient("123; reboot").is_err());
     }
 }

--- a/agent/src/system.rs
+++ b/agent/src/system.rs
@@ -1,4 +1,4 @@
-use std::collections::{HashMap, VecDeque};
+use std::collections::{HashMap, HashSet, VecDeque};
 use std::fs;
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
@@ -419,21 +419,56 @@ fn read_sysfs_u64(path: &str) -> Option<u64> {
 
 // -- Process monitor --
 
-/// Known bloat daemons (from daemon-cleanup.md).
-const BLOAT_DAEMONS: &[&str] = &[
-    "zte_topsw_tr069",
+/// Optional services documented as safe to stop in `docs/SAFETY.md`.
+///
+/// This allowlist is only the first safety gate.  At runtime we also parse the
+/// firmware's daemon synchronization barrier and exclude every process it
+/// names.  If that file cannot be read, stopping services fails closed.
+const SAFE_OPTIONAL_DAEMONS: &[&str] = &[
     "zte_topsw_tr069_sub",
-    "zte_topsw_fota_result",
     "zte_mqtt_sdk_st",
     "zte_topsw_diag",
     "zte_topsw_samba",
     "zte_topsw_nfc",
-    "zte_smart_manage",
     "zte_topsw_get_brand",
     "zte_topsw_jwxk_query",
     "zte-topsw-tunnel",
-    "zte_dua",
+    "zte_topsw_dua",
 ];
+
+const DAEMON_SYNC_CONFIG: &str = "/etc/config/zte_topsw_daemon.conf";
+
+fn parse_daemon_sync_config(content: &str) -> HashSet<String> {
+    content
+        .lines()
+        .filter_map(|line| {
+            let line = line.trim();
+            if line.is_empty() || line.starts_with('#') {
+                return None;
+            }
+            let columns: Vec<&str> = line.split_whitespace().collect();
+            if columns.first().copied() == Some("sync") && columns.len() >= 3 {
+                columns.last().map(|name| (*name).to_string())
+            } else {
+                None
+            }
+        })
+        .collect()
+}
+
+fn protected_daemons(path: &str) -> Result<HashSet<String>, String> {
+    let content = fs::read_to_string(path)
+        .map_err(|e| format!("cannot verify firmware daemon safety barrier: {e}"))?;
+    let protected = parse_daemon_sync_config(&content);
+    if protected.is_empty() {
+        return Err("firmware daemon safety barrier contained no sync entries".to_string());
+    }
+    Ok(protected)
+}
+
+fn is_safe_optional_daemon(name: &str, protected: &HashSet<String>) -> bool {
+    SAFE_OPTIONAL_DAEMONS.contains(&name) && !protected.contains(name)
+}
 
 #[derive(Serialize, Clone)]
 pub struct ProcessEntry {
@@ -495,6 +530,9 @@ impl ProcessTracker {
     }
 
     fn sample_fresh(&self) -> ProcessListResult {
+        // An unreadable or malformed barrier deliberately produces no
+        // stop-eligible processes in the UI.
+        let protected = protected_daemons(DAEMON_SYNC_CONFIG).ok();
         let total_ticks = read_total_cpu_ticks();
         let mut prev = self.prev.safe_lock();
         let (prev_per_pid, prev_total) = &*prev;
@@ -580,7 +618,9 @@ impl ProcessTracker {
                 });
 
             let display_name = cmdline_name.as_deref().unwrap_or(&comm);
-            let is_bloat = BLOAT_DAEMONS.iter().any(|&b| display_name == b);
+            let is_bloat = protected
+                .as_ref()
+                .is_some_and(|names| is_safe_optional_daemon(display_name, names));
 
             let state_desc = match state_char.as_str() {
                 "R" => "running",
@@ -655,8 +695,10 @@ fn read_total_cpu_ticks() -> u64 {
     0
 }
 
-/// Kill bloat daemons. If `pids` is None, kill all running bloat.
-pub fn kill_bloat(pids: Option<&[u32]>) -> KillBloatResult {
+/// Gracefully stop optional daemons. If `pids` is None, stop every running
+/// allowlisted process. The firmware sync barrier is always authoritative.
+pub fn kill_bloat(pids: Option<&[u32]>) -> Result<KillBloatResult, String> {
+    let protected = protected_daemons(DAEMON_SYNC_CONFIG)?;
     let mut killed = Vec::new();
     let mut skipped = Vec::new();
     let mut freed_rss_kb: u64 = 0;
@@ -674,11 +716,11 @@ pub fn kill_bloat(pids: Option<&[u32]>) -> KillBloatResult {
             let proc_dir = match fs::read_dir("/proc") {
                 Ok(d) => d,
                 Err(_) => {
-                    return KillBloatResult {
+                    return Ok(KillBloatResult {
                         killed,
                         skipped,
                         freed_rss_kb,
-                    }
+                    })
                 }
             };
             proc_dir
@@ -686,7 +728,7 @@ pub fn kill_bloat(pids: Option<&[u32]>) -> KillBloatResult {
                 .filter_map(|entry| {
                     let pid: u32 = entry.file_name().to_string_lossy().parse().ok()?;
                     let (name, rss) = read_proc_name_rss(pid)?;
-                    if BLOAT_DAEMONS.iter().any(|&b| b == name) {
+                    if is_safe_optional_daemon(&name, &protected) {
                         Some((pid, name, rss))
                     } else {
                         None
@@ -697,11 +739,13 @@ pub fn kill_bloat(pids: Option<&[u32]>) -> KillBloatResult {
     };
 
     for (pid, name, rss_kb) in targets {
-        if !BLOAT_DAEMONS.iter().any(|&b| b == name) {
+        // Re-check the name read from /proc immediately before signalling it.
+        // This protects explicit PID requests and PID reuse races alike.
+        if !is_safe_optional_daemon(&name, &protected) {
             skipped.push(KilledProcess { pid, name });
             continue;
         }
-        let ret = unsafe { libc::kill(pid as i32, libc::SIGKILL) };
+        let ret = unsafe { libc::kill(pid as i32, libc::SIGTERM) };
         if ret == 0 {
             freed_rss_kb += rss_kb;
             killed.push(KilledProcess { pid, name });
@@ -710,11 +754,11 @@ pub fn kill_bloat(pids: Option<&[u32]>) -> KillBloatResult {
         }
     }
 
-    KillBloatResult {
+    Ok(KillBloatResult {
         killed,
         skipped,
         freed_rss_kb,
-    }
+    })
 }
 
 fn read_proc_name_rss(pid: u32) -> Option<(String, u64)> {
@@ -819,5 +863,28 @@ mod tests {
                 .collect::<Vec<_>>(),
             ["cpu_pct", "is_bloat", "name", "pid", "rss_kb", "state"]
         );
+    }
+
+    #[test]
+    fn daemon_sync_parser_only_accepts_active_sync_rows() {
+        let parsed = parse_daemon_sync_config(
+            "# comment\nsync ALL zte_router\n sync  ALL  zte_topsw_wms \nstart ALL ignored\n",
+        );
+        assert_eq!(parsed.len(), 2);
+        assert!(parsed.contains("zte_router"));
+        assert!(parsed.contains("zte_topsw_wms"));
+    }
+
+    #[test]
+    fn optional_daemon_must_not_cross_firmware_barrier() {
+        let protected = HashSet::from([
+            "zte_topsw_diag".to_string(),
+            "zte_topsw_wms".to_string(),
+        ]);
+        assert!(!is_safe_optional_daemon("zte_topsw_diag", &protected));
+        assert!(!is_safe_optional_daemon("zte_topsw_wms", &protected));
+        assert!(is_safe_optional_daemon("zte_topsw_samba", &protected));
+        assert!(!is_safe_optional_daemon("zte_topsw_fota_result", &protected));
+        assert!(!is_safe_optional_daemon("zte_smart_manage", &protected));
     }
 }

--- a/agent/src/wifi.rs
+++ b/agent/src/wifi.rs
@@ -124,6 +124,26 @@ fn sanitize_wifi_input_value(key: &str, v: &str) -> String {
     }
 }
 
+fn bandwidth_options(hwmode: &str, standards: &str, is_5g: bool) -> Vec<String> {
+    let mode = hwmode.to_ascii_lowercase();
+    let supported: Vec<String> = standards
+        .split(',')
+        .map(|value| value.trim().to_ascii_lowercase())
+        .collect();
+    let has = |standard: &str| supported.iter().any(|value| value == standard);
+    let prefix = if mode.contains("be") || has("be") {
+        "EHT"
+    } else if mode.contains("ax") || has("ax") {
+        "HE"
+    } else if is_5g && (mode.contains("ac") || has("ac")) {
+        "VHT"
+    } else {
+        "HT"
+    };
+    let widths: &[u16] = if is_5g { &[20, 40, 80, 160] } else { &[20, 40] };
+    widths.iter().map(|width| format!("{prefix}{width}")).collect()
+}
+
 // ---------------------------------------------------------------------------
 // GET /api/wifi/status
 // ---------------------------------------------------------------------------
@@ -182,6 +202,27 @@ pub fn wifi_status(_state: &AppState) -> (u16, Value) {
     );
     result.insert("htmode_2g".into(), json!(cfg.get("wifi0.htmode")));
     result.insert("htmode_5g".into(), json!(cfg.get("wifi1.htmode")));
+    let hwmode_2g = cfg.get("wifi0.hwmode");
+    let hwmode_5g = cfg.get("wifi1.hwmode");
+    let standards_2g = cfg.get("wifi0.SupportedStandards");
+    let standards_5g = cfg.get("wifi1.SupportedStandards");
+    result.insert("hwmode_2g".into(), json!(hwmode_2g));
+    result.insert("hwmode_5g".into(), json!(hwmode_5g));
+    result.insert("supported_standards_2g".into(), json!(standards_2g));
+    result.insert("supported_standards_5g".into(), json!(standards_5g));
+    result.insert(
+        "bandwidth_options_2g".into(),
+        json!(bandwidth_options(&hwmode_2g, &standards_2g, false)),
+    );
+    result.insert(
+        "bandwidth_options_5g".into(),
+        json!(bandwidth_options(&hwmode_5g, &standards_5g, true)),
+    );
+    result.insert(
+        "wifi7_supported".into(),
+        json!(standards_2g.split(',').any(|s| s.trim() == "be")
+            || standards_5g.split(',').any(|s| s.trim() == "be")),
+    );
     result.insert(
         "country_code".into(),
         json!(cfg.get("wifi0.country")),
@@ -262,6 +303,23 @@ pub fn wifi_set(_state: &AppState, body: &[u8]) -> (u16, Value) {
         Some(o) => o,
         None => return (400, json!({"ok": false, "error": "expected JSON object"})),
     };
+    let cfg = WifiConfig::load();
+    for (key, value) in obj {
+        if key == "htmode_2g" || key == "htmode_5g" {
+            let Some(value) = value.as_str() else {
+                return (400, json!({"ok": false, "error": format!("{key} must be a string")}));
+            };
+            let is_5g = key == "htmode_5g";
+            let options = if is_5g {
+                bandwidth_options(&cfg.get("wifi1.hwmode"), &cfg.get("wifi1.SupportedStandards"), true)
+            } else {
+                bandwidth_options(&cfg.get("wifi0.hwmode"), &cfg.get("wifi0.SupportedStandards"), false)
+            };
+            if !options.iter().any(|option| option == value) {
+                return (400, json!({"ok": false, "error": format!("{value} is not supported by this radio; allowed values: {}", options.join(", "))}));
+            }
+        }
+    }
 
     let uci_map: &[(&str, &str)] = &[
         ("ssid_2g", "wireless.main_2g.ssid"),
@@ -461,7 +519,7 @@ pub fn wifi_set(_state: &AppState, body: &[u8]) -> (u16, Value) {
 
 #[cfg(test)]
 mod tests {
-    use super::sanitize_wifi_input_value;
+    use super::{bandwidth_options, sanitize_wifi_input_value};
 
     #[test]
     fn wifi_keys_keep_special_characters() {
@@ -483,5 +541,17 @@ mod tests {
     fn non_key_values_remain_sanitized() {
         let input = r#"wifi$';`"\name|<&"#;
         assert_eq!(sanitize_wifi_input_value("ssid_5g", input), "wifiname");
+    }
+
+    #[test]
+    fn wifi7_radios_use_eht_bandwidth_names() {
+        assert_eq!(
+            bandwidth_options("11beg", "b,g,n,ax,be", false),
+            ["EHT20", "EHT40"]
+        );
+        assert_eq!(
+            bandwidth_options("11bea", "a,n,ac,ax,be", true),
+            ["EHT20", "EHT40", "EHT80", "EHT160"]
+        );
     }
 }

--- a/docs/EMULATION.md
+++ b/docs/EMULATION.md
@@ -82,7 +82,11 @@ Stubbed or absent (hardware-dependent):
 - `zwrt_bsp.thermal` — real daemon exits without `/sys/class/thermal/*`; stub
   returns `{"cpu_temp": 42}`. Battery/charger values come back as `-2`
   (firmware's own "unavailable" sentinel) since QEMU has no power-supply sysfs.
-- SMS send/receive — `zwrt_wms` registers but has no modem behind it.
+- The stock `zwrt_wms` still registers without modem hardware and remains
+  available for read-only comparison. Agent/dashboard SMS tests use the
+  separate emulator-only `zte_agent_emu_wms` object, selected through
+  `ZTE_AGENT_WMS_OBJECT`; it implements the same list/send/status/tag/delete
+  payloads without shadowing or changing the stock daemon.
 - Wi-Fi radios — no cfg80211 hardware in the VM.
 
 ## Stock web UI fidelity

--- a/docs/SAFETY.md
+++ b/docs/SAFETY.md
@@ -61,8 +61,9 @@ zte_topsw_jwxk_query, zte_topsw_tr069_sub, zte_mqtt_sdk_st,
 zte_topsw_dua, zte-topsw-tunnel
 ```
 
-The agent's `kill-bloat` endpoint (`agent/src/system.rs` `BLOAT_PROCESSES`)
-deliberately contains only the safe list. Do not add daemon.conf names to it
+The agent's `kill-bloat` endpoint (`agent/src/system.rs` `SAFE_OPTIONAL_DAEMONS`)
+contains only the safe list and subtracts the live daemon.conf barrier at
+runtime. An unreadable or empty barrier blocks the operation. Do not add daemon.conf names to it
 (killing `zte_topsw_wms` breaks SMS, `zte_topsw_sleep_faw` breaks wakelocks,
 and procd will respawn them anyway).
 
@@ -199,8 +200,8 @@ regained and this is deployed again.
 ## 4. v2.1 features ported, and what was deliberately NOT ported
 
 Ported (safe, gated): charge control (`zwrt_bsp.charger`, inverted semantics
-handled), USB powerbank (`zwrt_bsp.powerbank set`), SMS sqlite-delete
-fallback for SIM-stored messages, `/api/at/port`, WiFi dual UCI namespace
+handled), USB powerbank (`zwrt_bsp.powerbank set`), firmware WMS SMS translation
+with readiness gating (no direct database writes), `/api/at/port`, WiFi dual UCI namespace
 (`zte_mbb.wifi.*` + `wireless.zte_mbb.*`) with guest-time read.
 
 **Rejected from v2.1 (safety regressions):**

--- a/scripts/check-device-secrets.py
+++ b/scripts/check-device-secrets.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+"""Reject device identity values and backup-key material in tracked files."""
+
+from __future__ import annotations
+
+import re
+import subprocess
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+DEVICE_ID = re.compile(
+    rb"(?i)\b(?:imei|imsi|iccid|sim_imei|sim_imsi|sim_iccid)\b"
+    rb"[^\r\n]{0,80}?[\"']([0-9]{14,22})[\"']"
+)
+LITERAL_SUFFIX = re.compile(
+    rb"(?im)\bZTE_BACKUP_SUFFIX\s*=\s*([\"'])([^\"'\r\n]+)\1"
+)
+PRIVATE_KEY = re.compile(rb"-----BEGIN (?:[A-Z ]+ )?PRIVATE KEY-----")
+TOKEN = re.compile(
+    rb"(?:ghp_[A-Za-z0-9]{20,}|github_pat_[A-Za-z0-9_]{20,}|"
+    rb"AKIA[0-9A-Z]{16}|AIza[0-9A-Za-z_-]{20,}|sk-[A-Za-z0-9]{20,}|"
+    rb"sk-(?:proj|svcacct)-[A-Za-z0-9_-]{20,})"
+)
+
+
+def candidate_files() -> list[Path]:
+    result = subprocess.run(
+        ["git", "ls-files", "-z", "--cached", "--others", "--exclude-standard"],
+        cwd=ROOT,
+        check=True,
+        stdout=subprocess.PIPE,
+    )
+    return [ROOT / item.decode() for item in result.stdout.split(b"\0") if item]
+
+
+def main() -> int:
+    failures: list[str] = []
+    for path in candidate_files():
+        try:
+            data = path.read_bytes()
+        except (FileNotFoundError, IsADirectoryError):
+            continue
+
+        if DEVICE_ID.search(data):
+            failures.append(f"{path.relative_to(ROOT)}: hard-coded device identity")
+        for match in LITERAL_SUFFIX.finditer(data):
+            value = match.group(2).strip()
+            if value and not value.startswith((b"$", b"<")):
+                failures.append(f"{path.relative_to(ROOT)}: literal ZTE backup suffix")
+                break
+        if PRIVATE_KEY.search(data):
+            failures.append(f"{path.relative_to(ROOT)}: private key material")
+        if TOKEN.search(data):
+            failures.append(f"{path.relative_to(ROOT)}: credential-like token")
+
+    if failures:
+        print("Device-secret audit failed:")
+        for failure in failures:
+            print(f"  {failure}")
+        return 1
+
+    print("OK: no tracked device identities, ZTE backup suffixes, private keys, or credential tokens")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/emulate.sh
+++ b/scripts/emulate.sh
@@ -37,6 +37,11 @@ build_payload() {
 
 	cp "target/$TARGET/release/zte-agent" "$EMU/payload/root/"
 	cp "$EMU/fakemodem/target/$TARGET/release/fakemodem" "$EMU/payload/root/"
+	# Tracked emulator overlays. The firmware images and expanded payload tree
+	# are intentionally gitignored, so test doubles must be copied from here.
+	cp scripts/emulator-payload/install.sh "$EMU/payload/root/install.sh"
+	mkdir -p "$EMU/payload/root/rpcd"
+	cp scripts/emulator-payload/zte_agent_emu_wms "$EMU/payload/root/rpcd/zte_agent_emu_wms"
 	chmod +x "$EMU/payload/root/"* 2>/dev/null || true
 	# Optional full stock-UI asset tree pulled from a live device:
 	#   tar czf - -C / usr/zte_web/web  →  unpack into firmware/emulation/payload/ztedata/

--- a/scripts/emulator-payload/install.sh
+++ b/scripts/emulator-payload/install.sh
@@ -1,0 +1,44 @@
+#!/bin/sh
+# Emulation payload installer - mirrors the real device deploy layout.
+set -x
+mkdir -p /data/local/tmp
+cp /payload/zte-agent /data/zte-agent
+cp /payload/fakemodem /data/local/tmp/fakemodem
+chmod +x /data/zte-agent /data/local/tmp/fakemodem
+
+killall fakemodem 2>/dev/null
+nohup /data/local/tmp/fakemodem >/tmp/fakemodem.log 2>&1 &
+sleep 1
+
+# Management network on eth1 (QEMU hostfwd NIC).
+udhcpc -i eth1 -q -n 2>/dev/null
+ip addr show eth1 | grep 'inet '
+
+cat > /data/local/tmp/start_zte_agent.sh <<'EOS'
+#!/bin/sh
+export ZTE_AGENT_PASSWORD='emu-test-password'
+export ZTE_AGENT_BIND='0.0.0.0:9090'
+export ZTE_AGENT_WMS_OBJECT='zte_agent_emu_wms'
+nohup sh -c '/data/zte-agent 2>&1 | logger -t zte-agent' >/dev/null 2>&1 </dev/null &
+EOS
+chmod +x /data/local/tmp/start_zte_agent.sh
+killall zte-agent 2>/dev/null
+sleep 1
+sh /data/local/tmp/start_zte_agent.sh
+
+# Objects whose stock daemons need physical modem/thermal hardware.
+if [ -d /payload/rpcd ]; then
+	mkdir -p /data/emu
+	cp /payload/netinfo.json /data/emu/ 2>/dev/null
+	cp /payload/rpcd/* /usr/libexec/rpcd/
+	chmod +x /usr/libexec/rpcd/zte_nwinfo_api /usr/libexec/rpcd/zwrt_bsp.thermal /usr/libexec/rpcd/zte_agent_emu_wms
+	/etc/init.d/rpcd restart
+fi
+
+if [ -d /payload/webui ]; then
+	cp -R /payload/webui/. /usr/zte_web/web/
+fi
+if [ -d /payload/ztedata ]; then
+	cp -R /payload/ztedata/. /usr/zte_web/web/
+fi
+echo "PAYLOAD INSTALLED"

--- a/scripts/emulator-payload/zte_agent_emu_wms
+++ b/scripts/emulator-payload/zte_agent_emu_wms
@@ -1,0 +1,80 @@
+#!/bin/sh
+# Emulator-only WMS object implementing the stock agent-facing contract.
+
+. /usr/share/libubox/jshn.sh
+
+STATE=/tmp/zte_agent_emu_wms_messages
+NEXT_ID=/tmp/zte_agent_emu_wms_next_id
+
+init_state() {
+	[ -f "$STATE" ] || {
+		printf '%s\n' \
+			'9001|+61412345678|00570065006C0063006F006D006500200074006F0020007400680065002000550036003000200065006D0075006C00610074006F0072|26;08;16;10;00;00;+10|1|1' \
+			'9002|+61498765432|0052006500610064007900200066006F0072002000740065007300740069006E0067|26;08;15;09;30;00;+10|0|1' \
+			'9003|+61400000000|00500072006500760069006F00750073002000730065006E00740020006D006500730073006100670065|26;08;14;08;15;00;+10|2|1' > "$STATE"
+	}
+	[ -f "$NEXT_ID" ] || echo 9004 > "$NEXT_ID"
+}
+
+case "$1" in
+list)
+	cat <<'EOF'
+{ "zwrt_wms_get_cmd_status": {"sms_cmd":0},
+  "zte_libwms_get_sms_data": {"page":0,"data_per_page":0,"mem_store":0,"tags":0,"order_by":""},
+  "zte_libwms_send_sms": {"number":"","sms_time":"","message_body":"","id":"","encode_type":""},
+  "zwrt_wms_delete_sms": {"id":""},
+  "zwrt_wms_modify_tag": {"id":"","tag":0} }
+EOF
+	;;
+call)
+	init_state
+	method="$2"
+	input="$(cat)"
+	case "$method" in
+	zwrt_wms_get_cmd_status)
+		json_load "$input"
+		json_get_var sms_cmd sms_cmd
+		printf '{"sms_cmd":"%s","sms_cmd_status_result":"3"}\n' "${sms_cmd:-1}"
+		;;
+	zte_libwms_get_sms_data)
+		awk -F'|' 'BEGIN { printf "{\"messages\":[" }
+			{ if (count++) printf ","; printf "{\"id\":%s,\"number\":\"%s\",\"content\":\"%s\",\"date\":\"%s\",\"tag\":%s,\"mem_store\":%s}",$1,$2,$3,$4,$5,$6 }
+			END { print "]}" }' "$STATE"
+		;;
+	zte_libwms_send_sms)
+		json_load "$input"
+		json_get_var number number
+		json_get_var sms_time sms_time
+		json_get_var message_body message_body
+		json_get_var encode_type encode_type
+		if [ -z "$number" ] || [ -z "$message_body" ] || [ -z "$sms_time" ] || [ -z "$encode_type" ]; then
+			echo '{"result":"failed"}'
+			exit 1
+		fi
+		id="$(cat "$NEXT_ID")"
+		printf '%s\n' "$((id + 1))" > "$NEXT_ID"
+		printf '%s|%s|%s|%s|2|1\n' "$id" "$number" "$message_body" "$sms_time" >> "$STATE"
+		echo '{"result":"success"}'
+		;;
+	zwrt_wms_delete_sms)
+		json_load "$input"
+		json_get_var ids id
+		awk -F'|' -v ids="$ids" 'BEGIN { n=split(ids,a,";"); for(i=1;i<=n;i++) remove[a[i]]=1 } !remove[$1]' "$STATE" > "$STATE.tmp"
+		mv "$STATE.tmp" "$STATE"
+		echo '{"result":"success"}'
+		;;
+	zwrt_wms_modify_tag)
+		json_load "$input"
+		json_get_var ids id
+		json_get_var tag tag
+		awk -F'|' -v OFS='|' -v ids="$ids" -v tag="$tag" 'BEGIN { n=split(ids,a,";"); for(i=1;i<=n;i++) change[a[i]]=1 } { if(change[$1]) $5=tag; print }' "$STATE" > "$STATE.tmp"
+		mv "$STATE.tmp" "$STATE"
+		echo '{"result":"success"}'
+		;;
+	*)
+		echo '{"result":"unsupported"}'
+		exit 1
+		;;
+	esac
+	;;
+esac

--- a/scripts/test-emulator-fixes.py
+++ b/scripts/test-emulator-fixes.py
@@ -1,0 +1,266 @@
+#!/usr/bin/env python3
+"""Guarded end-to-end checks for the fixes requested in the safety review.
+
+The script refuses non-loopback targets, verifies the emulator-only WMS object,
+and restores LAN, Wi-Fi, network mode, APN mode/profile and band-lock state.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+
+
+BASE = "http://127.0.0.1:9090"
+PASSWORD = "emu-test-password"
+
+
+class Api:
+    def __init__(self) -> None:
+        parsed = urllib.parse.urlparse(BASE)
+        if parsed.hostname not in {"127.0.0.1", "localhost", "::1"}:
+            raise RuntimeError("refusing to test a non-loopback API")
+        self.token = ""
+
+    def request(self, method: str, path: str, body=None, headers=None):
+        payload = None if body is None else json.dumps(body).encode()
+        request_headers = dict(headers or {})
+        if payload is not None:
+            request_headers["Content-Type"] = "application/json"
+        if self.token:
+            request_headers["Authorization"] = f"Bearer {self.token}"
+        request = urllib.request.Request(
+            BASE + path, data=payload, method=method, headers=request_headers
+        )
+        try:
+            with urllib.request.urlopen(request, timeout=20) as response:
+                return response.status, json.load(response)
+        except urllib.error.HTTPError as error:
+            return error.code, json.load(error)
+
+    def login(self) -> None:
+        status, response = self.request(
+            "POST", "/api/auth/login", {"password": PASSWORD}
+        )
+        assert status == 200 and response["ok"]
+        self.token = response["data"]["token"]
+
+    def ok(self, method: str, path: str, body=None, headers=None):
+        status, response = self.request(method, path, body, headers)
+        assert status == 200 and response.get("ok") is True, (status, response)
+        return response.get("data", {})
+
+
+def test_emulator_guard(api: Api) -> None:
+    capabilities = api.ok("GET", "/api/sms/capabilities")
+    assert capabilities["object"] == "zte_agent_emu_wms", capabilities
+    assert capabilities["available"] and capabilities["ready"]
+
+
+def test_kill_bloat(api: Api) -> None:
+    status, _ = api.request("POST", "/api/system/kill-bloat", {"pids": [1]})
+    assert status == 400
+    result = api.ok(
+        "POST",
+        "/api/system/kill-bloat",
+        {"pids": [1]},
+        {"X-Confirm": "true"},
+    )
+    assert result["killed"] == [], result
+    assert result["skipped"] and result["skipped"][0]["pid"] == 1, result
+
+
+def test_lan(api: Api) -> None:
+    baseline = api.ok("GET", "/api/router/lan")
+    assert baseline == {
+        "ipaddr": "192.168.0.1",
+        "netmask": "255.255.255.0",
+        "dhcp_enabled": True,
+        "dhcp_start": "192.168.0.2",
+        "dhcp_end": "192.168.0.253",
+        "lease_seconds": 86400,
+    }, baseline
+    status, _ = api.request("PUT", "/api/router/lan", {"lan_ipaddr": baseline["ipaddr"]})
+    assert status == 400
+    changed = {**baseline, "lease_seconds": 82800}
+    try:
+        api.ok("PUT", "/api/router/lan", changed)
+        assert api.ok("GET", "/api/router/lan")["lease_seconds"] == 82800
+        disabled = {**changed, "dhcp_enabled": False}
+        api.ok("PUT", "/api/router/lan", disabled)
+        assert api.ok("GET", "/api/router/lan")["dhcp_enabled"] is False
+    finally:
+        api.ok("PUT", "/api/router/lan", baseline)
+    assert api.ok("GET", "/api/router/lan") == baseline
+
+
+def test_modem_capabilities_and_locks(api: Api) -> None:
+    capabilities = api.ok("GET", "/api/modem/capabilities")
+    assert [mode["value"] for mode in capabilities["network_modes"]] == [
+        "WL_AND_5G",
+        "LTE_AND_5G",
+        "Only_5G",
+        "WCDMA_AND_LTE",
+        "Only_LTE",
+        "Only_WCDMA",
+    ]
+    assert capabilities["lte_bands"] == [
+        1, 2, 3, 4, 5, 7, 8, 18, 19, 20, 26, 28, 29, 32, 34, 38, 39,
+        40, 41, 42, 43, 48, 66, 71,
+    ]
+    assert capabilities["nr_sa_bands"][-3:] == [77, 78, 79]
+
+    dashboard = api.ok("GET", "/api/dashboard")
+    baseline_mode = dashboard["signal"].get("net_select", "WL_AND_5G")
+    status, _ = api.request("PUT", "/api/modem/network-mode", {"net_select": "LTE_ONLY"})
+    assert status == 400
+    try:
+        api.ok("PUT", "/api/modem/network-mode", {"net_select": "WCDMA_AND_LTE"})
+    finally:
+        api.ok("PUT", "/api/modem/network-mode", {"net_select": baseline_mode})
+
+    lte_mask = str((1 << (1 - 1)) | (1 << (71 - 1)))
+    api.ok("POST", "/api/cell/band/lte", {
+        "is_lte_band": "1", "lte_band_mask": lte_mask,
+        "is_gw_band": "0", "gw_band_mask": "0",
+    })
+    status, _ = api.request("POST", "/api/cell/band/lte", {
+        "is_lte_band": "1", "lte_band_mask": str(1 << 11),
+        "is_gw_band": "0", "gw_band_mask": "0",
+    })
+    assert status == 400
+    api.ok("POST", "/api/cell/band/nr", {"nr5g_type": "SA", "nr5g_band": "1,78"})
+    status, _ = api.request("POST", "/api/cell/band/nr", {"nr5g_type": "SA", "nr5g_band": "12"})
+    assert status == 400
+    api.ok("POST", "/api/cell/band/reset")
+
+
+def test_wifi7(api: Api) -> None:
+    baseline = api.ok("GET", "/api/wifi/status")
+    assert baseline["htmode_2g"] == "EHT40"
+    assert baseline["htmode_5g"] == "EHT160"
+    assert baseline["bandwidth_options_2g"] == ["EHT20", "EHT40"]
+    assert baseline["bandwidth_options_5g"] == ["EHT20", "EHT40", "EHT80", "EHT160"]
+    assert baseline["wifi7_supported"] is True
+    status, _ = api.request("PUT", "/api/wifi/settings", {"htmode_2g": "HT40"})
+    assert status == 400
+    try:
+        api.ok("PUT", "/api/wifi/settings", {"htmode_2g": "EHT20"})
+        assert api.ok("GET", "/api/wifi/status")["htmode_2g"] == "EHT20"
+    finally:
+        api.ok("PUT", "/api/wifi/settings", {"htmode_2g": baseline["htmode_2g"]})
+    assert api.ok("GET", "/api/wifi/status")["htmode_2g"] == baseline["htmode_2g"]
+
+
+def test_unavailable_hardware(api: Api) -> None:
+    thermal = api.ok("GET", "/api/device/thermal/all")
+    battery = api.ok("GET", "/api/device/battery/detail")
+    bsp = api.ok("GET", "/api/device/battery-info")
+    charge = api.ok("GET", "/api/device/charge-control")
+    assert thermal == {"available": False}, thermal
+    assert battery["available"] is False
+    for key, value in battery.items():
+        if key != "available":
+            assert value is None, (key, value)
+    assert bsp["available"] is False
+    assert all(value is None for key, value in bsp.items() if key != "available")
+    assert charge["capacity"] is None and charge["battery_available"] is False
+
+
+def test_apn(api: Api) -> None:
+    baseline_mode = api.ok("GET", "/api/router/apn/mode")["apn_mode"]
+    baseline_profiles = api.ok("GET", "/api/router/apn/profiles")["apnListArray"]
+    original_active = next((profile for profile in baseline_profiles if profile.get("isEnable")), None)
+    name = f"CodexEmu{int(time.time()) % 100000}"
+    created_id = None
+    api.ok("POST", "/api/router/apn/profiles", {
+        "profilename": name,
+        "wanapn": "emulator.test",
+        "username": "",
+        "password": "",
+        "pppAuthMode": 0,
+        "pdpType": 3,
+    })
+    try:
+        profiles = api.ok("GET", "/api/router/apn/profiles")["apnListArray"]
+        created = next(profile for profile in profiles if profile.get("profilename") == name)
+        created_id = str(created["profileId"])
+        assert created["wanapn"] == "emulator.test" and int(created["pdpType"]) == 3
+        api.ok("POST", "/api/router/apn/profiles/activate", {"profileId": created_id})
+        profiles = api.ok("GET", "/api/router/apn/profiles")["apnListArray"]
+        assert any(str(profile["profileId"]) == created_id and profile.get("isEnable") for profile in profiles)
+        status, _ = api.request("POST", "/api/router/apn/profiles/delete", {"profileId": created_id})
+        assert status == 409
+    finally:
+        if original_active:
+            api.ok("POST", "/api/router/apn/profiles/activate", {"profileId": str(original_active["profileId"])})
+        api.ok("PUT", "/api/router/apn/mode", {"apn_mode": int(baseline_mode)})
+        if created_id:
+            api.ok("POST", "/api/router/apn/profiles/delete", {"profileId": created_id})
+    remaining = api.ok("GET", "/api/router/apn/profiles")["apnListArray"]
+    assert not any(profile.get("profilename") == name for profile in remaining)
+
+
+def test_sms(api: Api) -> None:
+    messages = api.ok("POST", "/api/sms/list", {"page": 0, "per_page": 500})["messages"]
+    unread = next(message for message in messages if int(message["tag"]) == 1)
+    api.ok("POST", "/api/sms/read", {"ids": [int(unread["id"])]})
+    after_read = api.ok("POST", "/api/sms/list", {"page": 0, "per_page": 500})["messages"]
+    assert next(message for message in after_read if message["id"] == unread["id"])["tag"] == 0
+
+    text = f"Emulator SMS {int(time.time())}"
+    status, _ = api.request("POST", "/api/sms/send", {"to": "+61400000000", "text": text})
+    assert status == 400
+    api.ok("POST", "/api/sms/send", {"number": "+61400000000", "message": text})
+    messages = api.ok("POST", "/api/sms/list", {"page": 0, "per_page": 500})["messages"]
+    encoded = "".join(f"{ord(character):04X}" for character in text)
+    sent = next(message for message in messages if message["content"] == encoded)
+    assert sent["tag"] == 2 and sent["mem_store"] == 1
+    api.ok("POST", "/api/sms/delete", {"ids": [int(sent["id"])]})
+    messages = api.ok("POST", "/api/sms/list", {"page": 0, "per_page": 500})["messages"]
+    assert not any(message["id"] == sent["id"] for message in messages)
+
+
+def test_at_read_only(api: Api) -> None:
+    result = api.ok("POST", "/api/at/send", {"command": "AT+CSQ", "timeout": 3})
+    assert "OK" in result["response"]
+    for command in ("AT+CSQ=1", "AT+FOO", "AT+CFUN=1"):
+        status, _ = api.request("POST", "/api/at/send", {"command": command, "timeout": 3})
+        assert status == 403, (command, status)
+
+
+def main() -> int:
+    api = Api()
+    api.login()
+    tests = [
+        ("emulator guard + SMS capability", test_emulator_guard),
+        ("kill-bloat confirmation and PID allowlist", test_kill_bloat),
+        ("LAN/DHCP exact payload + restore", test_lan),
+        ("network modes and LTE/NR bands", test_modem_capabilities_and_locks),
+        ("Wi-Fi 7 EHT bandwidth + restore", test_wifi7),
+        ("unavailable sensor semantics", test_unavailable_hardware),
+        ("manual APN create/activate/delete + restore", test_apn),
+        ("SMS list/read/send/delete", test_sms),
+        ("read-only AT query", test_at_read_only),
+    ]
+    failures = []
+    for name, function in tests:
+        try:
+            function(api)
+            print(f"PASS  {name}")
+        except Exception as error:  # continue so every restore/fix gets exercised
+            failures.append((name, error))
+            print(f"FAIL  {name}: {error}")
+    if failures:
+        print(f"\n{len(failures)} integration check(s) failed", file=sys.stderr)
+        return 1
+    print(f"\nPASS  all {len(tests)} guarded emulator checks")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/web-app/src/data/api.ts
+++ b/web-app/src/data/api.ts
@@ -22,10 +22,12 @@ import type {
   LoggerDownload,
   LoggerStatus,
   MemInfo,
+  ModemCapabilities,
   ProcessListResult,
   SignalInfo,
   SimInfo,
   SmsMessage,
+  SmsCapabilities,
   SpeedInfo,
   ThermalAll,
   ThermalInfo,
@@ -448,6 +450,8 @@ function mapWifi(d: Record<string, unknown>): WifiAll {
       bandwidth: actualBw2g,
       configuredChannel: configuredChannel2g === '0' ? 'auto' : configuredChannel2g,
       configuredBandwidth: d.htmode_2g as string | undefined,
+      bandwidthOptions: d.bandwidth_options_2g as string[] | undefined,
+      supportedStandards: d.supported_standards_2g as string | undefined,
       actualChannel: actualChannel2g,
       actualBandwidth: actualBw2g,
       password: (d.key_2g as string) || (d.has_key_2g ? '••••••••' : undefined),
@@ -462,6 +466,8 @@ function mapWifi(d: Record<string, unknown>): WifiAll {
       bandwidth: actualBw5g,
       configuredChannel: configuredChannel5g === '0' ? 'auto' : configuredChannel5g,
       configuredBandwidth: d.htmode_5g as string | undefined,
+      bandwidthOptions: d.bandwidth_options_5g as string[] | undefined,
+      supportedStandards: d.supported_standards_5g as string | undefined,
       actualChannel: actualChannel5g,
       actualBandwidth: actualBw5g,
       password: (d.key_5g as string) || (d.has_key_5g ? '••••••••' : undefined),
@@ -474,6 +480,7 @@ function mapWifi(d: Record<string, unknown>): WifiAll {
     master_enabled: masterEnabled,
     wifi6_supported: wifi6Supported,
     wifi6_enabled: wifi6Enabled,
+    wifi7_supported: parseBoolLike(d.wifi7_supported, false),
   }
 }
 
@@ -488,11 +495,12 @@ function mapDns(d: Record<string, unknown>): DnsConfig {
 
 function mapLan(d: Record<string, unknown>): LanConfig {
   return {
-    ip: (d.lan_ipaddr as string) || '',
-    netmask: (d.lan_netmask as string) || '',
+    ipaddr: (d.ipaddr as string) || '',
+    netmask: (d.netmask as string) || '',
+    dhcp_enabled: d.dhcp_enabled === true,
     dhcp_start: (d.dhcp_start as string) || '',
     dhcp_end: (d.dhcp_end as string) || '',
-    dhcp_lease: (d.dhcp_lease_time as string) || '',
+    lease_seconds: Number(d.lease_seconds) || 0,
   }
 }
 
@@ -574,11 +582,12 @@ function mapThermal(d: Record<string, unknown>): ThermalInfo {
 
 function mapBatteryBspInfo(d: Record<string, unknown>): BatteryBspInfo {
   return {
-    online: d.battery_online === 1,
-    low_power: d.battery_low_power === 1,
-    using_hw_fg_chip: d.battery_using_hw_fg_chip === 1,
-    time_to_full_mins: d.battery_time_to_full as number | undefined,
-    time_to_empty_mins: d.battery_time_to_empty as number | undefined,
+    available: d.available === true,
+    online: typeof d.online === 'boolean' ? d.online : null,
+    low_power: typeof d.low_power === 'boolean' ? d.low_power : null,
+    using_hw_fg_chip: typeof d.using_hw_fg_chip === 'boolean' ? d.using_hw_fg_chip : null,
+    time_to_full_mins: typeof d.time_to_full_mins === 'number' ? d.time_to_full_mins : null,
+    time_to_empty_mins: typeof d.time_to_empty_mins === 'number' ? d.time_to_empty_mins : null,
   }
 }
 
@@ -622,6 +631,7 @@ export const api = {
   // Modem / SIM
   simInfo: () => get('/api/sim/info').then(mapSim),
   simImei: () => get('/api/sim/imei'),
+  modemCapabilities: () => get('/api/modem/capabilities').then((d) => d as unknown as ModemCapabilities),
   networkModeSet: (net_select: string) => put('/api/modem/network-mode', { net_select }),
 
   // WiFi
@@ -653,18 +663,19 @@ export const api = {
   apnDelete: (body: Record<string, unknown>) => post('/api/router/apn/profiles/delete', body),
   apnActivate: (body: Record<string, unknown>) => post('/api/router/apn/profiles/activate', body),
 
-  // SMS (firmware expects legacy semicolon-joined id strings: "12;34;")
-  smsList: (box: number) =>
-    post('/api/sms/list', { cmd: 1, page: 0, data_per_page: 500, mem_store: box, tags: 0, order_by: 'date,desc' }).then(
-      mapSmsList,
-    ),
-  smsSend: (to: string, text: string) => post('/api/sms/send', { to, text }),
-  smsDelete: (ids: number[]) => post('/api/sms/delete', { id: ids.map((n) => `${n};`).join('') }),
-  smsRead: (ids: number[]) => post('/api/sms/read', { id: ids.map((n) => `${n};`).join(''), tag: 0 }),
+  // SMS: the agent owns translation to ZTE's legacy WMS payloads.
+  smsCapabilities: () => get('/api/sms/capabilities').then((d) => d as unknown as SmsCapabilities),
+  smsList: () => post('/api/sms/list', { page: 0, per_page: 500 }).then(mapSmsList),
+  smsSend: (number: string, message: string) => post('/api/sms/send', { number, message }),
+  smsDelete: (ids: number[]) => post('/api/sms/delete', { ids }),
+  smsRead: (ids: number[]) => post('/api/sms/read', { ids }),
 
   // System
   top: () => get('/api/system/top').then((d) => d as unknown as ProcessListResult),
-  killBloat: () => post('/api/system/kill-bloat', { all: true }).then((d) => d as unknown as KillBloatResult),
+  killBloat: () =>
+    post('/api/system/kill-bloat', { all: true }, { 'X-Confirm': 'true' }).then(
+      (d) => d as unknown as KillBloatResult,
+    ),
   restartAgent: () => post('/api/system/restart-agent', {}),
 
   // USB

--- a/web-app/src/features/modem/ApnTab.tsx
+++ b/web-app/src/features/modem/ApnTab.tsx
@@ -5,22 +5,6 @@ import { Button, Field, Input, Select } from '../../ui/controls'
 import { toast, toastError, confirm } from '../../ui/feedback'
 import { Card, Chip, Empty, Skeleton } from '../../ui/primitives'
 
-const APN_PRESETS: { name: string; apn: string; user: string; pass: string; auth: number; pdp: number }[] = [
-  { name: 'Vodafone AU', apn: 'live.vodafone.com', user: '', pass: '', auth: 0, pdp: 3 },
-  { name: 'Optus', apn: 'yesinternet', user: '', pass: '', auth: 0, pdp: 3 },
-  { name: 'Telstra', apn: 'telstra.internet', user: '', pass: '', auth: 0, pdp: 3 },
-  { name: 'T-Mobile US', apn: 'fast.t-mobile.com', user: '', pass: '', auth: 0, pdp: 3 },
-  { name: 'AT&T', apn: 'broadband', user: '', pass: '', auth: 0, pdp: 3 },
-  { name: 'Verizon', apn: 'vzwinternet', user: '', pass: '', auth: 0, pdp: 3 },
-  { name: 'EE UK', apn: 'everywhere', user: 'eesecure', pass: 'secure', auth: 2, pdp: 3 },
-  { name: 'Three UK', apn: 'three.co.uk', user: '', pass: '', auth: 0, pdp: 3 },
-  { name: 'Vodafone UK', apn: 'wap.vodafone.co.uk', user: 'wap', pass: 'wap', auth: 1, pdp: 3 },
-  { name: 'DoCoMo', apn: 'ppsim.jp', user: 'pp@sim', pass: 'jpn', auth: 2, pdp: 3 },
-  { name: 'SoftBank', apn: 'plus.4g', user: 'plus', pass: '4g', auth: 2, pdp: 3 },
-  { name: 'KDDI au', apn: 'uad5gn.au-net.ne.jp', user: '', pass: '', auth: 0, pdp: 3 },
-  { name: 'Generic IPv4v6', apn: 'internet', user: '', pass: '', auth: 0, pdp: 3 },
-]
-
 const PDP_LABELS: Record<number, string> = { 1: 'IPv4', 2: 'IPv6', 3: 'IPv4v6' }
 const AUTH_LABELS: Record<number, string> = { 0: 'None', 1: 'PAP', 2: 'CHAP', 3: 'PAP/CHAP' }
 
@@ -32,7 +16,7 @@ function ApnMode() {
 
   useEffect(() => {
     api.apnModeGet()
-      .then((d) => setMode((d?.apn_mode as number) ?? 0))
+      .then((d) => setMode(Number(d?.apn_mode) || 0))
       .catch(() => {})
   }, [])
 
@@ -91,7 +75,17 @@ function Profiles() {
     try {
       const data = await api.apnProfiles()
       const list = data?.apnListArray
-      setProfiles(Array.isArray(list) ? (list as ApnProfile[]) : [])
+      setProfiles(
+        Array.isArray(list)
+          ? (list as Record<string, unknown>[]).map((profile) => ({
+              ...profile,
+              profileId: String(profile.profileId),
+              pdpType: Number(profile.pdpType),
+              pppAuthMode: Number(profile.pppAuthMode),
+              isEnable: profile.isEnable === true || profile.isEnable === 1 || profile.isEnable === '1',
+            })) as ApnProfile[]
+          : [],
+      )
     } catch {
       setProfiles([])
     }
@@ -146,18 +140,13 @@ function Profiles() {
     }
   }
 
-  function applyPreset(p: (typeof APN_PRESETS)[0]) {
-    setForm({ name: p.name, apn: p.apn, user: p.user, pass: p.pass, auth: p.auth, pdp: p.pdp })
-    setAdding(true)
-  }
-
   return (
     <>
       <Card title="APN profiles">
         {loading ? (
           <Skeleton className="h-20" />
         ) : profiles.length === 0 ? (
-          <Empty title="No manual APN profiles" body="Add one below or pick a preset." />
+          <Empty title="No manual APN profiles" body="Add the exact settings supplied by your carrier." />
         ) : (
           <div className="space-y-2">
             {profiles.map((p) => (
@@ -183,7 +172,7 @@ function Profiles() {
                       Activate
                     </Button>
                   )}
-                  <Button size="sm" variant="ghost" onClick={() => deleteProfile(p.profileId)}>
+                  <Button size="sm" variant="ghost" disabled={p.isEnable} onClick={() => deleteProfile(p.profileId)} title={p.isEnable ? 'Switch to another APN before deleting this profile' : undefined}>
                     Delete
                   </Button>
                 </div>
@@ -206,7 +195,7 @@ function Profiles() {
               <Input value={form.user} onChange={(e) => setForm((f) => ({ ...f, user: e.target.value }))} placeholder="(optional)" />
             </Field>
             <Field label="Password">
-              <Input value={form.pass} onChange={(e) => setForm((f) => ({ ...f, pass: e.target.value }))} placeholder="(optional)" />
+              <Input type="password" autoComplete="new-password" value={form.pass} onChange={(e) => setForm((f) => ({ ...f, pass: e.target.value }))} placeholder="(optional)" />
             </Field>
             <Field label="Authentication">
               <Select value={form.auth} onChange={(e) => setForm((f) => ({ ...f, auth: parseInt(e.target.value) }))}>
@@ -239,20 +228,6 @@ function Profiles() {
         </Button>
       )}
 
-      <Card title="Quick presets">
-        <p className="mb-2 text-[12px] text-ink2">Tap a preset to pre-fill the add form.</p>
-        <div className="flex flex-wrap gap-1.5">
-          {APN_PRESETS.map((p) => (
-            <button
-              key={p.name}
-              onClick={() => applyPreset(p)}
-              className="rounded-lg bg-surface2 px-2.5 py-1.5 text-[12px] font-semibold text-ink2 transition-colors hover:bg-line/10 hover:text-ink"
-            >
-              {p.name}
-            </button>
-          ))}
-        </div>
-      </Card>
     </>
   )
 }

--- a/web-app/src/features/modem/SmsTab.tsx
+++ b/web-app/src/features/modem/SmsTab.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useState } from 'react'
 import { api } from '../../data/api'
-import type { SmsMessage } from '../../types'
+import type { SmsCapabilities, SmsMessage } from '../../types'
 import { IMessage, IPlus } from '../../icons'
 import { Button, Field, Input, Segmented } from '../../ui/controls'
 import { toast, toastError, confirm } from '../../ui/feedback'
@@ -12,7 +12,11 @@ const BOX_SENT = 2
 function formatDate(d?: string) {
   if (!d) return ''
   try {
-    return new Date(d).toLocaleString()
+    const stock = d.match(/^(\d{2});(\d{2});(\d{2});(\d{2});(\d{2});(\d{2})/)
+    const value = stock
+      ? new Date(2000 + Number(stock[1]), Number(stock[2]) - 1, Number(stock[3]), Number(stock[4]), Number(stock[5]), Number(stock[6]))
+      : new Date(d)
+    return Number.isNaN(value.getTime()) ? d : value.toLocaleString()
   } catch {
     return d
   }
@@ -27,11 +31,17 @@ export default function SmsTab() {
   const [to, setTo] = useState('')
   const [text, setText] = useState('')
   const [sending, setSending] = useState(false)
+  const [capabilities, setCapabilities] = useState<SmsCapabilities | null | undefined>(undefined)
+
+  useEffect(() => {
+    api.smsCapabilities().then(setCapabilities).catch(() => setCapabilities(null))
+  }, [])
 
   const load = useCallback(async () => {
     setLoading(true)
     try {
-      setMessages(await api.smsList(box))
+      const all = await api.smsList()
+      setMessages(all.filter((message) => box === BOX_INBOX ? message.tag === 0 || message.tag === 1 : message.tag === 2 || message.tag === 3))
     } catch {
       setMessages([])
     } finally {
@@ -40,8 +50,9 @@ export default function SmsTab() {
   }, [box])
 
   useEffect(() => {
-    load()
-  }, [load])
+    if (capabilities?.available && capabilities.ready) load()
+    else if (capabilities !== undefined) setLoading(false)
+  }, [capabilities, load])
 
   async function markRead(id: number) {
     try {
@@ -66,9 +77,9 @@ export default function SmsTab() {
 
   function openMsg(m: SmsMessage) {
     setSelected(m)
-    if (m.tag === 0) {
+    if (m.tag === 1) {
       markRead(m.id)
-      setMessages((ms) => ms.map((x) => (x.id === m.id ? { ...x, tag: 1 } : x)))
+      setMessages((ms) => ms.map((x) => (x.id === m.id ? { ...x, tag: 0 } : x)))
     }
   }
 
@@ -89,7 +100,20 @@ export default function SmsTab() {
     }
   }
 
-  const unread = messages.filter((m) => m.tag === 0).length
+  const unread = messages.filter((m) => m.tag === 1).length
+
+  if (capabilities === undefined) return <Skeleton className="h-64" />
+  if (!capabilities?.available || !capabilities.ready) {
+    return (
+      <Card title="SMS unavailable">
+        <Empty
+          icon={<IMessage size={26} />}
+          title="Firmware WMS is not ready"
+          body={capabilities?.reason ?? 'The agent could not verify the SMS service, so listing, sending, and deletion are disabled.'}
+        />
+      </Card>
+    )
+  }
 
   return (
     <div className="space-y-3">
@@ -166,10 +190,10 @@ export default function SmsTab() {
                     }`}
                   >
                     <div className="flex items-start justify-between gap-2">
-                      <p className={`truncate text-[13px] ${m.tag === 0 ? 'font-bold text-ink' : 'font-medium text-ink2'}`}>
+                      <p className={`truncate text-[13px] ${m.tag === 1 ? 'font-bold text-ink' : 'font-medium text-ink2'}`}>
                         {m.number || '—'}
                       </p>
-                      {m.tag === 0 && <span className="mt-1 h-2 w-2 shrink-0 rounded-full bg-accent" />}
+                      {m.tag === 1 && <span className="mt-1 h-2 w-2 shrink-0 rounded-full bg-accent" />}
                     </div>
                     <p className="mt-0.5 truncate text-[12px] text-ink3">{m.content}</p>
                     <p className="tnum mt-0.5 text-[11px] text-ink3">{formatDate(m.date)}</p>

--- a/web-app/src/features/network/RouterTab.tsx
+++ b/web-app/src/features/network/RouterTab.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react'
 import { api } from '../../data/api'
 import type { DnsConfig, LanConfig } from '../../types'
-import { Button, Field, Input } from '../../ui/controls'
+import { Button, Field, Input, Toggle } from '../../ui/controls'
 import { toast, toastError } from '../../ui/feedback'
 import { Card } from '../../ui/primitives'
 
@@ -79,7 +79,14 @@ function DnsSection() {
 }
 
 function LanSection() {
-  const [lan, setLan] = useState<LanConfig>({ ip: '', netmask: '', dhcp_start: '', dhcp_end: '', dhcp_lease: '' })
+  const [lan, setLan] = useState<LanConfig>({
+    ipaddr: '',
+    netmask: '',
+    dhcp_enabled: true,
+    dhcp_start: '',
+    dhcp_end: '',
+    lease_seconds: 86400,
+  })
   const [busy, setBusy] = useState(false)
 
   useEffect(() => {
@@ -90,11 +97,12 @@ function LanSection() {
     setBusy(true)
     try {
       await api.lanSet({
-        lan_ipaddr: lan.ip,
-        lan_netmask: lan.netmask,
+        ipaddr: lan.ipaddr,
+        netmask: lan.netmask,
+        dhcp_enabled: lan.dhcp_enabled,
         dhcp_start: lan.dhcp_start,
         dhcp_end: lan.dhcp_end,
-        dhcp_lease_time: lan.dhcp_lease,
+        lease_seconds: lan.lease_seconds,
       })
       toast('LAN settings saved')
     } catch (e) {
@@ -108,20 +116,35 @@ function LanSection() {
     <Card title="LAN / DHCP">
       <div className="grid grid-cols-1 gap-2.5 lg:grid-cols-2">
         <Field label="LAN IP">
-          <Input value={lan.ip} onChange={(e) => setLan((l) => ({ ...l, ip: e.target.value }))} inputMode="numeric" />
+          <Input value={lan.ipaddr} onChange={(e) => setLan((l) => ({ ...l, ipaddr: e.target.value }))} inputMode="numeric" />
         </Field>
         <Field label="Netmask">
           <Input value={lan.netmask} onChange={(e) => setLan((l) => ({ ...l, netmask: e.target.value }))} inputMode="numeric" />
         </Field>
         <Field label="DHCP start">
-          <Input value={lan.dhcp_start} onChange={(e) => setLan((l) => ({ ...l, dhcp_start: e.target.value }))} inputMode="numeric" />
+          <Input disabled={!lan.dhcp_enabled} value={lan.dhcp_start} onChange={(e) => setLan((l) => ({ ...l, dhcp_start: e.target.value }))} inputMode="numeric" />
         </Field>
         <Field label="DHCP end">
-          <Input value={lan.dhcp_end} onChange={(e) => setLan((l) => ({ ...l, dhcp_end: e.target.value }))} inputMode="numeric" />
+          <Input disabled={!lan.dhcp_enabled} value={lan.dhcp_end} onChange={(e) => setLan((l) => ({ ...l, dhcp_end: e.target.value }))} inputMode="numeric" />
         </Field>
-        <Field label="Lease time (seconds)">
-          <Input value={lan.dhcp_lease} onChange={(e) => setLan((l) => ({ ...l, dhcp_lease: e.target.value }))} inputMode="numeric" />
+        <Field label="Lease time (hours)" hint="The firmware stores this value in seconds.">
+          <Input
+            type="number"
+            min={1}
+            max={168}
+            disabled={!lan.dhcp_enabled}
+            value={lan.lease_seconds / 3600}
+            onChange={(e) => setLan((l) => ({ ...l, lease_seconds: Math.round(Number(e.target.value) * 3600) }))}
+            inputMode="numeric"
+          />
         </Field>
+      </div>
+      <div className="mt-3 flex items-center justify-between rounded-lg bg-surface2/60 px-3 py-2.5">
+        <div>
+          <p className="text-[13px] font-semibold text-ink">DHCP server</p>
+          <p className="text-[11px] text-ink3">Assign addresses to LAN and Wi-Fi clients</p>
+        </div>
+        <Toggle checked={lan.dhcp_enabled} onChange={(dhcp_enabled) => setLan((l) => ({ ...l, dhcp_enabled }))} label="DHCP server" />
       </div>
       <div className="mt-3.5">
         <Button variant="primary" onClick={save} loading={busy}>

--- a/web-app/src/features/network/WifiTab.tsx
+++ b/web-app/src/features/network/WifiTab.tsx
@@ -14,7 +14,7 @@ function normalizeConfiguredChannel(channel?: string) {
 
 function formatBandwidthMode(mode?: string) {
   if (!mode) return '\u2014'
-  if (mode.startsWith('HT')) return `${mode.replace('HT', '')} MHz`
+  if (/^(EHT|HE|VHT|HT)\d+$/.test(mode)) return `${mode.replace(/^(EHT|HE|VHT|HT)/, '')} MHz (${mode.match(/^(EHT|HE|VHT|HT)/)?.[0]})`
   return mode
 }
 
@@ -81,7 +81,7 @@ function BandCard({
     setPassword(band.password ?? '')
     setPasswordDirty(false)
     setChannel(normalizeConfiguredChannel(band.configuredChannel))
-    setHtmode((band.configuredBandwidth ?? '').startsWith('HT') ? (band.configuredBandwidth ?? '') : '')
+    setHtmode(band.configuredBandwidth ?? '')
     setTxpower('')
     setHidden(band.hidden)
   }, [band])
@@ -94,8 +94,8 @@ function BandCard({
         [`hidden_${suffix}`]: hidden ? '1' : '0',
       }
       if (passwordDirty) settings[`key_${suffix}`] = password
-      if (channel) settings[`channel_${suffix}`] = channel
-      if (htmode) settings[`htmode_${suffix}`] = htmode
+      if (channel && channel !== normalizeConfiguredChannel(band.configuredChannel)) settings[`channel_${suffix}`] = channel
+      if (htmode && htmode !== band.configuredBandwidth) settings[`htmode_${suffix}`] = htmode
       if (txpower) settings[`txpower_${suffix}`] = txpower
       await api.wifiSet(settings)
       toast('Saved — Wi-Fi may reconnect')
@@ -127,7 +127,7 @@ function BandCard({
     suffix === '2g'
       ? ['auto', '1', '2', '3', '4', '5', '6', '7', '8', '9', '10', '11', '12', '13']
       : ['auto', '36', '40', '44', '48', '52', '56', '60', '64', '100', '104', '108', '112', '116', '120', '124', '128', '132', '136', '140', '144', '149', '153', '157', '161', '165']
-  const htmodes = suffix === '2g' ? ['HT20', 'HT40'] : ['HT20', 'HT40', 'HT80', 'HT160']
+  const htmodes = band.bandwidthOptions?.length ? band.bandwidthOptions : [band.configuredBandwidth].filter(Boolean) as string[]
   const configuredChannel = normalizeConfiguredChannel(band.configuredChannel)
   const insights = getBandInsights(suffix, band)
 
@@ -150,7 +150,7 @@ function BandCard({
                 setPassword(band.password ?? '')
                 setPasswordDirty(false)
                 setChannel(normalizeConfiguredChannel(band.configuredChannel))
-                setHtmode((band.configuredBandwidth ?? '').startsWith('HT') ? (band.configuredBandwidth ?? '') : '')
+                setHtmode(band.configuredBandwidth ?? '')
                 setTxpower('')
                 setHidden(band.hidden)
               }}
@@ -214,7 +214,7 @@ function BandCard({
                 <Select value={htmode} onChange={(e) => setHtmode(e.target.value)}>
                   {htmodes.map((m) => (
                     <option key={m} value={m}>
-                      {m.replace('HT', '')} MHz
+                      {formatBandwidthMode(m)}
                     </option>
                   ))}
                 </Select>
@@ -366,6 +366,11 @@ export default function WifiTab() {
         {wifi.wifi6_supported && (
           <div className="mt-3 border-t border-line/8 pt-3">
             <Chip tone={wifi.wifi6_enabled ? 'ok' : 'default'}>Wi-Fi 6 {wifi.wifi6_enabled ? 'enabled' : 'disabled'}</Chip>
+          </div>
+        )}
+        {wifi.wifi7_supported && (
+          <div className="mt-3 border-t border-line/8 pt-3">
+            <Chip tone="ok">Wi-Fi 7 / 802.11be supported</Chip>
           </div>
         )}
       </Card>

--- a/web-app/src/features/signal/Locking.tsx
+++ b/web-app/src/features/signal/Locking.tsx
@@ -1,25 +1,14 @@
 import { useEffect, useState } from 'react'
 import { useHome } from '../../app/HomeContext'
 import { api } from '../../data/api'
-import type { SignalInfo } from '../../types'
+import type { ModemCapabilities, SignalInfo } from '../../types'
 import { Button, Field, Input } from '../../ui/controls'
 import { toast, toastError, confirm } from '../../ui/feedback'
 import { Card, Chip, Skeleton } from '../../ui/primitives'
 
-const NR_BANDS = [1, 2, 3, 5, 7, 8, 18, 20, 26, 28, 29, 38, 40, 41, 48, 66, 71, 75, 77, 78, 79]
-const LTE_BANDS = [1, 2, 3, 4, 5, 7, 8, 12, 13, 14, 17, 18, 19, 20, 25, 26, 28, 29, 30, 32, 34, 38, 39, 40, 41, 42, 43, 48, 66, 71]
-
-const NETWORK_MODES: { value: string; label: string }[] = [
-  { value: 'WL_AND_5G', label: '5G + 4G' },
-  { value: 'Only_5G', label: '5G SA' },
-  { value: 'LTE_AND_5G', label: '5G NSA' },
-  { value: 'Only_LTE', label: '4G LTE' },
-  { value: 'Only_WCDMA', label: '3G' },
-]
-
 // ── Network mode ──────────────────────────────────────────────────────────────
 
-function NetworkMode({ currentMode, onApplied }: { currentMode: string; onApplied: () => void }) {
+function NetworkMode({ currentMode, modes, onApplied }: { currentMode: string; modes: ModemCapabilities['network_modes']; onApplied: () => void }) {
   const [selected, setSelected] = useState(currentMode)
   const [busy, setBusy] = useState(false)
 
@@ -44,7 +33,7 @@ function NetworkMode({ currentMode, onApplied }: { currentMode: string; onApplie
         Preferred network technology. The modem reconnects after a change.
       </p>
       <div className="flex flex-wrap gap-1.5">
-        {NETWORK_MODES.map((m) => (
+        {modes.map((m) => (
           <button
             key={m.value}
             onClick={() => setSelected(m.value)}
@@ -64,7 +53,7 @@ function NetworkMode({ currentMode, onApplied }: { currentMode: string; onApplie
         </Button>
         {selected !== currentMode && (
           <span className="text-[12px] text-ink3">
-            Current: {NETWORK_MODES.find((m) => m.value === currentMode)?.label ?? currentMode}
+            Current: {modes.find((m) => m.value === currentMode)?.label ?? currentMode}
           </span>
         )}
       </div>
@@ -286,6 +275,11 @@ export default function Locking() {
   // `refresh` re-runs that batch after a lock is applied.
   const { data: home, refresh } = useHome()
   const signal = home?.signal ?? null
+  const [capabilities, setCapabilities] = useState<ModemCapabilities | null | undefined>(undefined)
+
+  useEffect(() => {
+    api.modemCapabilities().then(setCapabilities).catch(() => setCapabilities(null))
+  }, [])
 
   async function handleLockCell(type: 'nr' | 'lte', pci: number, earfcn: number, band?: string) {
     try {
@@ -343,15 +337,23 @@ export default function Locking() {
 
   return (
     <div className="space-y-3">
-      <NetworkMode currentMode={signal.net_select ?? 'WL_AND_5G'} onApplied={refresh} />
+      {capabilities ? (
+        <NetworkMode currentMode={signal.net_select ?? 'WL_AND_5G'} modes={capabilities.network_modes} onApplied={refresh} />
+      ) : capabilities === undefined ? (
+        <Skeleton className="h-40" />
+      ) : (
+        <Card title="Network mode and bands">
+          <p className="text-[12px] text-warn">Firmware capability data is unavailable, so radio mode and band changes are disabled.</p>
+        </Card>
+      )}
 
       <ServingCells signal={signal} onLock={handleLockCell} />
 
-      <div className="grid grid-cols-1 gap-3 lg:grid-cols-2">
+      {capabilities && <div className="grid grid-cols-1 gap-3 lg:grid-cols-2">
         <BandLock
           title="NR 5G band lock"
           description="Allowed NR bands. Works in 5G SA mode only — firmware does not support NSA band locking."
-          bands={NR_BANDS}
+          bands={capabilities.nr_sa_bands}
           type="nr"
           lockedBands={signal.nr_band_lock}
           onApplied={refresh}
@@ -359,12 +361,12 @@ export default function Locking() {
         <BandLock
           title="LTE band lock"
           description="Allowed LTE bands."
-          bands={LTE_BANDS}
+          bands={capabilities.lte_bands}
           type="lte"
           lockedBands={signal.lte_band_lock}
           onApplied={refresh}
         />
-      </div>
+      </div>}
 
       <div className="grid grid-cols-1 gap-3 lg:grid-cols-2">
         <CellLock type="nr" onApplied={refresh} />

--- a/web-app/src/features/system/MetricsTab.tsx
+++ b/web-app/src/features/system/MetricsTab.tsx
@@ -16,8 +16,15 @@ interface MetricsData {
   mem: MemInfo | null
 }
 
-function ThermalBar({ label, value }: { label: string; value?: number }) {
-  if (value == null) return null
+function ThermalBar({ label, value }: { label: string; value?: number | null }) {
+  if (value == null) {
+    return (
+      <div className="flex justify-between text-[12px]">
+        <span className="text-ink2">{label}</span>
+        <span className="font-medium text-ink3">Unavailable</span>
+      </div>
+    )
+  }
   const pct = Math.min((value / 100) * 100, 100)
   const tone = value > 80 ? 'bg-danger' : value > 60 ? 'bg-warn' : 'bg-ok'
   return (
@@ -65,13 +72,14 @@ function ChargeControlCard() {
           <div className="min-w-0">
             <p className="text-[13px] font-medium text-ink">Charging</p>
             <p className="truncate text-[12px] text-ink2">
-              {cc.battery_status || '\u2014'} at {cc.capacity}%{cc.manual_override ? ' · manual override' : ''}
+              {cc.battery_status ?? 'Battery data unavailable'}{cc.capacity != null ? ` at ${cc.capacity}%` : ''}{cc.manual_override ? ' · manual override' : ''}
             </p>
           </div>
           <Button
             size="sm"
             variant={cc.charging_stopped ? 'primary' : 'outline'}
             loading={busy}
+            disabled={!cc.charger_available}
             onClick={() => apply({ charging_stopped: !cc.charging_stopped })}
           >
             {cc.charging_stopped ? 'Resume charging' : 'Stop charging'}
@@ -88,7 +96,7 @@ function ChargeControlCard() {
             </div>
             <Toggle
               checked={cc.charge_limit_enabled}
-              disabled={busy}
+              disabled={busy || !cc.battery_available}
               onChange={(v) => apply({ charge_limit_enabled: v })}
               label="Charge limit enforcer"
             />
@@ -100,7 +108,7 @@ function ChargeControlCard() {
               max={100}
               step={5}
               value={limit ?? cc.charge_limit}
-              disabled={busy || !cc.charge_limit_enabled}
+              disabled={busy || !cc.charge_limit_enabled || !cc.battery_available}
               onChange={(e) => setLimit(Number(e.target.value))}
               onPointerDown={() => setDragging(true)}
               onPointerUp={(e) => {
@@ -120,6 +128,7 @@ function ChargeControlCard() {
           Firmware note: the charger switch is inverted (enable = stop). Charging auto-resumes when the
           charger is unplugged or the limit is disabled.
         </p>
+        {!cc.available && <p className="text-[12px] font-medium text-warn">Battery and charger hardware data are unavailable; controls are disabled.</p>}
       </div>
     </Card>
   )
@@ -163,7 +172,7 @@ export default function MetricsTab() {
   const { thermal, battery, batteryInfo, cpu, mem } = data
 
   const cpuAvg =
-    thermal && thermal.cpu_0 != null
+    thermal?.available && thermal.cpu_0 != null
       ? [thermal.cpu_0, thermal.cpu_1, thermal.cpu_2, thermal.cpu_3]
           .filter((v): v is number => v != null)
           .reduce((a, b) => a + b, 0) /
@@ -171,14 +180,14 @@ export default function MetricsTab() {
       : undefined
 
   const batteryHealth =
-    battery && battery.charge_full_design_mah > 0
+    battery?.available && battery.charge_full_design_mah != null && battery.charge_full_design_mah > 0 && battery.charge_full_mah != null
       ? Math.round((battery.charge_full_mah / battery.charge_full_design_mah) * 100)
       : undefined
 
   return (
     <div className="grid grid-cols-1 gap-3 lg:grid-cols-2">
       <Card title="Temperatures">
-        {thermal ? (
+        {thermal?.available ? (
           <div className="space-y-2.5">
             <ThermalBar label="CPU (avg)" value={cpuAvg} />
             <ThermalBar label="Modem (Q6 DSP)" value={thermal.modem} />
@@ -192,7 +201,10 @@ export default function MetricsTab() {
             <ThermalBar label="Board (XO)" value={thermal.xo_therm} />
           </div>
         ) : (
-          <p className="text-[13px] text-ink3">No thermal data</p>
+          <div className="space-y-2.5">
+            <p className="text-[12px] font-medium text-warn">Thermal sensors are unavailable.</p>
+            {['CPU (avg)', 'Modem (Q6 DSP)', 'Modem SS', 'PA (power amplifier)', 'SDR (radio)', 'Battery', 'USB', 'Ethernet PHY', 'PMIC', 'Board (XO)'].map((label) => <ThermalBar key={label} label={label} />)}
+          </div>
         )}
       </Card>
 
@@ -244,52 +256,52 @@ export default function MetricsTab() {
       </div>
 
       <Card title="Battery">
-        {battery ? (
+        {battery?.available ? (
           <div className="space-y-3">
             <div>
               <div className="mb-1 flex justify-between text-[13px]">
-                <span className="tnum font-semibold text-ink">{battery.capacity}%</span>
-                <span className="text-ink2">{battery.status}</span>
+                <span className="tnum font-semibold text-ink">{battery.capacity != null ? `${battery.capacity}%` : 'Unavailable'}</span>
+                <span className="text-ink2">{battery.status ?? 'Unavailable'}</span>
               </div>
-              <Meter pct={battery.capacity} tone={battery.capacity > 20 ? 'bg-ok' : 'bg-danger'} />
+              {battery.capacity != null && <Meter pct={battery.capacity} tone={battery.capacity > 20 ? 'bg-ok' : 'bg-danger'} />}
             </div>
             <div className="grid grid-cols-2 gap-x-4 gap-y-2 text-[13px]">
-              <Info label="Power" value={`${(battery.power_mw / 1000).toFixed(2)} W`} />
-              <Info label="Voltage" value={`${(battery.voltage_mv / 1000).toFixed(3)} V`} />
-              <Info label="Current" value={`${battery.current_ma} mA`} />
-              <Info label="Charge type" value={battery.charge_type || '\u2014'} />
-              <Info label="Temperature" value={`${battery.temperature_c.toFixed(1)}°C`} cls={tempColorClass(battery.temperature_c)} />
+              <Info label="Power" value={formatMeasure(battery.power_mw, (value) => `${(value / 1000).toFixed(2)} W`)} />
+              <Info label="Voltage" value={formatMeasure(battery.voltage_mv, (value) => `${(value / 1000).toFixed(3)} V`)} />
+              <Info label="Current" value={formatMeasure(battery.current_ma, (value) => `${value} mA`)} />
+              <Info label="Charge type" value={battery.charge_type ?? 'Unavailable'} />
+              <Info label="Temperature" value={formatMeasure(battery.temperature_c, (value) => `${value.toFixed(1)}°C`)} cls={battery.temperature_c != null ? tempColorClass(battery.temperature_c) : 'text-ink3'} />
               <Info
                 label={battery.status === 'Charging' ? 'Time to full' : 'Time to empty'}
                 value={formatClock(battery.status === 'Charging' ? battery.time_to_full_secs : battery.time_to_empty_secs)}
               />
-              <Info label="Charge counter" value={`${battery.charge_counter_mah.toLocaleString()} mAh`} />
-              <Info label="Cycles" value={String(battery.cycle_count)} />
-              <Info label="Fuel gauge" value={batteryInfo ? (batteryInfo.using_hw_fg_chip ? 'Hardware' : 'Software') : '\u2014'} />
-              <Info label="Battery online" value={batteryInfo ? (batteryInfo.online ? 'Yes' : 'No') : '\u2014'} />
+              <Info label="Charge counter" value={formatMeasure(battery.charge_counter_mah, (value) => `${value.toLocaleString()} mAh`)} />
+              <Info label="Cycles" value={formatMeasure(battery.cycle_count, String)} />
+              <Info label="Fuel gauge" value={batteryInfo?.available && batteryInfo.using_hw_fg_chip != null ? (batteryInfo.using_hw_fg_chip ? 'Hardware' : 'Software') : 'Unavailable'} />
+              <Info label="Battery online" value={batteryInfo?.available && batteryInfo.online != null ? (batteryInfo.online ? 'Yes' : 'No') : 'Unavailable'} />
             </div>
           </div>
         ) : (
-          <p className="text-[13px] text-ink3">No battery data</p>
+          <p className="text-[13px] font-medium text-warn">Battery hardware data are unavailable.</p>
         )}
       </Card>
 
       <div className="space-y-3">
         <Card title="Battery health">
-          {battery ? (
+          {battery?.available ? (
             <div className="space-y-1.5 text-[13px]">
-              <KV k="Health" v={battery.health} />
-              <KV k="Capacity" v={`${battery.charge_full_mah.toLocaleString()} / ${battery.charge_full_design_mah.toLocaleString()} mAh`} />
+              <KV k="Health" v={battery.health ?? 'Unavailable'} />
+              <KV k="Capacity" v={battery.charge_full_mah != null && battery.charge_full_design_mah != null ? `${battery.charge_full_mah.toLocaleString()} / ${battery.charge_full_design_mah.toLocaleString()} mAh` : 'Unavailable'} />
               {batteryHealth != null && (
                 <div className="flex justify-between">
                   <span className="text-ink2">Capacity retention</span>
                   <span className={`tnum font-semibold ${batteryHealth > 80 ? 'text-ok' : 'text-warn'}`}>{batteryHealth}%</span>
                 </div>
               )}
-              <KV k="OCV" v={`${(battery.voltage_ocv_mv / 1000).toFixed(3)} V`} />
+              <KV k="OCV" v={formatMeasure(battery.voltage_ocv_mv, (value) => `${(value / 1000).toFixed(3)} V`)} />
             </div>
           ) : (
-            <p className="text-[13px] text-ink3">No battery data</p>
+          <p className="text-[13px] font-medium text-warn">Battery health measures are unavailable.</p>
           )}
         </Card>
 
@@ -317,8 +329,12 @@ function KV({ k, v }: { k: string; v: string }) {
   )
 }
 
-function formatClock(secs: number) {
-  if (secs <= 0) return '\u2014'
+function formatMeasure(value: number | null, format: (value: number) => string) {
+  return value == null ? 'Unavailable' : format(value)
+}
+
+function formatClock(secs: number | null) {
+  if (secs == null || secs <= 0) return 'Unavailable'
   const h = Math.floor(secs / 3600)
   const m = Math.floor((secs % 3600) / 60)
   return h > 0 ? `${h}h ${m}m` : `${m}m`

--- a/web-app/src/features/system/ToolsTab.tsx
+++ b/web-app/src/features/system/ToolsTab.tsx
@@ -3,7 +3,7 @@ import { api } from '../../data/api'
 import { usePoll } from '../../data/poll'
 import { formatBytes, formatDuration } from '../../format'
 import type { LoggerDownload, LoggerStatus, ProcessListResult } from '../../types'
-import { IRefresh } from '../../icons'
+import { IInfo, IRefresh } from '../../icons'
 import { Button, Field, Select } from '../../ui/controls'
 import { confirm, toast, toastError } from '../../ui/feedback'
 import { Card, Empty, Meter } from '../../ui/primitives'
@@ -201,9 +201,27 @@ function AtConsole() {
   }
 
   return (
-    <Card title="AT console">
+    <Card
+      title={
+        <span className="inline-flex items-center gap-1.5">
+          AT console
+          <span
+            className="inline-flex cursor-help text-warn"
+            title="AT commands talk directly to the modem. Incorrect write commands can disable connectivity or leave persistent modem settings behind."
+            aria-label="AT command safety information"
+          >
+            <IInfo size={14} />
+          </span>
+        </span>
+      }
+    >
+      <div role="alert" className="mb-3 rounded-lg border border-warn/30 bg-warn/10 px-3 py-2 text-[12px] text-warn">
+        <strong>Safety warning:</strong> AT commands bypass the normal settings APIs and talk directly to the modem.
+        Only use documented read-only queries; commands that write, reset, reboot, or alter radio state can interrupt service
+        or persist after the agent exits.
+      </div>
       <p className="mb-3 text-[12px] text-ink2">
-        Send AT commands to the modem. Read-only allowlist enforced by the agent.
+        The agent accepts only its read-only command allowlist.
         {port !== undefined && (
           <span className={port ? 'text-ok' : 'text-warn'}>{port ? ` Port: ${port}` : ' No AT port detected.'}</span>
         )}
@@ -275,9 +293,9 @@ function Processes() {
   async function killBloat() {
     if (!data) return
     const ok = await confirm({
-      title: `Kill ${data.bloat_count} bloat daemon${data.bloat_count === 1 ? '' : 's'}?`,
-      body: `Frees roughly ${formatBytes(data.bloat_rss_kb * 1024)} of RAM. These are ZTE telemetry and management daemons the agent treats as safe to kill; the firmware may restart some of them.`,
-      confirmLabel: 'Kill daemons',
+      title: `Stop ${data.bloat_count} optional service${data.bloat_count === 1 ? '' : 's'}?`,
+      body: `Frees roughly ${formatBytes(data.bloat_rss_kb * 1024)} of RAM. The agent re-checks the live firmware boot barrier, excludes every protected daemon, and sends only a graceful termination signal. The firmware may restart some services.`,
+      confirmLabel: 'Stop services',
       danger: true,
     })
     if (!ok) return
@@ -286,12 +304,12 @@ function Processes() {
       const result = await api.killBloat()
       toast(
         result.killed.length > 0
-          ? `Killed ${result.killed.length} daemon${result.killed.length === 1 ? '' : 's'}, freed ${formatBytes(result.freed_rss_kb * 1024)}`
-          : 'No bloat daemons were running',
+          ? `Stopped ${result.killed.length} optional service${result.killed.length === 1 ? '' : 's'}, freed ${formatBytes(result.freed_rss_kb * 1024)}`
+          : 'No optional services were running',
       )
       await load()
     } catch (e) {
-      toastError(e, 'Failed to kill bloat daemons')
+      toastError(e, 'Failed to stop optional services')
     } finally {
       setKilling(false)
     }
@@ -318,7 +336,7 @@ function Processes() {
           <div className="px-4 pb-3">
             <div className="flex flex-wrap items-center justify-between gap-2 rounded-lg bg-surface2/70 px-3 py-2.5">
               <div className="min-w-0">
-                <p className="text-[10px] font-semibold uppercase tracking-wider text-ink3">Bloat daemons</p>
+                <p className="text-[10px] font-semibold uppercase tracking-wider text-ink3">Optional services</p>
                 <p className="tnum mt-0.5 text-[13px] text-ink2">
                   {data.bloat_count} of {data.total_count} processes ·{' '}
                   <span className="font-semibold text-ink">{formatBytes(data.bloat_rss_kb * 1024)}</span> RAM ·{' '}
@@ -332,7 +350,7 @@ function Processes() {
                 loading={killing}
                 disabled={data.bloat_count === 0}
               >
-                Kill bloat daemons
+                Stop optional services
               </Button>
             </div>
           </div>

--- a/web-app/src/types.ts
+++ b/web-app/src/types.ts
@@ -143,6 +143,8 @@ export interface WifiBand {
   bandwidth?: string
   configuredChannel?: string
   configuredBandwidth?: string
+  bandwidthOptions?: string[]
+  supportedStandards?: string
   actualChannel?: number
   actualBandwidth?: string
   password?: string
@@ -159,6 +161,7 @@ export interface WifiAll {
   master_enabled: boolean
   wifi6_supported: boolean
   wifi6_enabled?: boolean
+  wifi7_supported: boolean
 }
 
 export interface DnsConfig {
@@ -169,11 +172,19 @@ export interface DnsConfig {
 }
 
 export interface LanConfig {
-  ip: string
+  ipaddr: string
   netmask: string
+  dhcp_enabled: boolean
   dhcp_start: string
   dhcp_end: string
-  dhcp_lease: string
+  lease_seconds: number
+}
+
+export interface ModemCapabilities {
+  network_modes: { value: string; label: string }[]
+  lte_bands: number[]
+  nr_sa_bands: number[]
+  nr_nsa_band_lock_supported: boolean
 }
 
 export interface ThermalInfo {
@@ -181,6 +192,7 @@ export interface ThermalInfo {
 }
 
 export interface ThermalAll {
+  available: boolean
   cpu_0?: number
   cpu_1?: number
   cpu_2?: number
@@ -199,36 +211,41 @@ export interface ThermalAll {
 }
 
 export interface BatteryBspInfo {
-  online: boolean
-  low_power: boolean
-  using_hw_fg_chip: boolean
-  time_to_full_mins?: number
-  time_to_empty_mins?: number
+  available: boolean
+  online: boolean | null
+  low_power: boolean | null
+  using_hw_fg_chip: boolean | null
+  time_to_full_mins: number | null
+  time_to_empty_mins: number | null
 }
 
 export interface BatteryDetail {
-  capacity: number
-  status: string
-  voltage_mv: number
-  voltage_max_mv: number
-  voltage_ocv_mv: number
-  current_ma: number
-  power_mw: number
-  temperature_c: number
-  charge_type: string
-  health: string
-  cycle_count: number
-  charge_counter_mah: number
-  charge_full_mah: number
-  charge_full_design_mah: number
-  time_to_full_secs: number
-  time_to_empty_secs: number
+  available: boolean
+  capacity: number | null
+  status: string | null
+  voltage_mv: number | null
+  voltage_max_mv: number | null
+  voltage_ocv_mv: number | null
+  current_ma: number | null
+  power_mw: number | null
+  temperature_c: number | null
+  charge_type: string | null
+  health: string | null
+  cycle_count: number | null
+  charge_counter_mah: number | null
+  charge_full_mah: number | null
+  charge_full_design_mah: number | null
+  time_to_full_secs: number | null
+  time_to_empty_secs: number | null
 }
 
 export interface ChargeControlState {
-  charging_stopped: boolean
-  battery_status: string
-  capacity: number
+  available: boolean
+  battery_available: boolean
+  charger_available: boolean
+  charging_stopped: boolean | null
+  battery_status: string | null
+  capacity: number | null
   charge_limit_enabled: boolean
   charge_limit: number
   hysteresis: number
@@ -278,10 +295,18 @@ export interface SmsMessage {
   number: string
   content: string
   date?: string
-  /** 0=unread, 1=read, 2=sent, 3=draft */
+  /** Firmware tags: 0=received/read, 1=received/unread, 2=sent, 3=failed, 4=draft. */
   tag: number
-  /** 0=SIM, 1=NV device storage */
+  /** Firmware storage: 1=native/NV device storage. */
   mem_store?: number
+}
+
+export interface SmsCapabilities {
+  available: boolean
+  ready: boolean
+  object: string
+  storage?: string
+  reason?: string
 }
 
 /** One row of `GET /api/system/top` — mirrors agent/src/system.rs::ProcessEntry. */

--- a/web-app/tools/mock_agent.py
+++ b/web-app/tools/mock_agent.py
@@ -156,11 +156,17 @@ def wifi_defaults():
     return {
         "wifi_onoff": "1", "wifi_onoff_supported": True,
         "wifi6_switch": "1", "wifi6_supported": True,
+        "wifi7_supported": True,
         "radio2_disabled": "0", "radio5_disabled": "0",
         "channel_2g": "0", "channel_5g": "44",
         "actual_channel_2g": 6, "actual_channel_5g": 44,
         "actual_bw_2g": "40 MHz", "actual_bw_5g": "160 MHz",
-        "htmode_2g": "HT40", "htmode_5g": "HT160",
+        "htmode_2g": "EHT40", "htmode_5g": "EHT160",
+        "hwmode_2g": "11beg", "hwmode_5g": "11bea",
+        "supported_standards_2g": "b,g,n,ax,be",
+        "supported_standards_5g": "a,n,ac,ax,be",
+        "bandwidth_options_2g": ["EHT20", "EHT40"],
+        "bandwidth_options_5g": ["EHT20", "EHT40", "EHT80", "EHT160"],
         "txpower_2g": "100", "txpower_5g": "100",
         "country_code": "AU",
         "ssid_2g": "U60Pro-Home", "ssid_5g": "U60Pro-Home",
@@ -204,6 +210,7 @@ def usb_defaults():
 
 def battery_detail():
     return {
+        "available": True,
         "capacity": 78, "status": "Charging",
         "voltage_mv": 4210, "voltage_max_mv": 4500, "voltage_ocv_mv": 4190,
         "current_ma": 1450, "power_mw": 6105, "temperature_c": 33.0,
@@ -215,6 +222,7 @@ def battery_detail():
 
 def thermal_all():
     return {
+        "available": True,
         "cpu_0": 61.2, "cpu_1": 60.8, "cpu_2": 59.7, "cpu_3": 60.1,
         "modem": 55.0, "modem_ss0": 52.0, "modem_ss1": 51.0, "modem_ss2": 50.0,
         "battery": 33.0, "usb": 38.0, "eth_phy": 44.0, "pmic": 49.0,
@@ -295,6 +303,7 @@ CONNECTION_LOG_CSV = (
 
 STATE = {
     "charge_control": {
+        "available": True, "battery_available": True, "charger_available": True,
         "charging_stopped": False, "battery_status": "Charging", "capacity": 78,
         "charge_limit_enabled": False, "charge_limit": 90, "hysteresis": 5,
         "manual_override": False,
@@ -309,9 +318,9 @@ STATE = {
         "ipv6_wan_standby_dns_manual": "2606:4700:4700::1001",
     },
     "lan": {
-        "lan_ipaddr": "192.168.0.1", "lan_netmask": "255.255.255.0",
-        "dhcp_start": "192.168.0.100", "dhcp_end": "192.168.0.200",
-        "dhcp_lease_time": "43200",
+        "ipaddr": "192.168.0.1", "netmask": "255.255.255.0", "dhcp_enabled": True,
+        "dhcp_start": "192.168.0.2", "dhcp_end": "192.168.0.253",
+        "lease_seconds": 86400,
     },
     "apn_mode": {"apn_mode": 1},
 }
@@ -410,18 +419,34 @@ ROUTES_GET = {
     "/api/device/thermal/all": thermal_all,
     "/api/device/battery/detail": battery_detail,
     "/api/device/battery-info": lambda: {
-        "battery_online": 1, "battery_low_power": 0, "battery_using_hw_fg_chip": 1,
-        "battery_time_to_full": 55, "battery_time_to_empty": 0,
+        "available": True, "online": True, "low_power": False, "using_hw_fg_chip": True,
+        "time_to_full_mins": 55, "time_to_empty_mins": 0,
+    },
+    "/api/modem/capabilities": lambda: {
+        "network_modes": [
+            {"value": "WL_AND_5G", "label": "5G / 4G / 3G"},
+            {"value": "LTE_AND_5G", "label": "5G NSA"},
+            {"value": "Only_5G", "label": "5G SA"},
+            {"value": "WCDMA_AND_LTE", "label": "4G / 3G"},
+            {"value": "Only_LTE", "label": "4G only"},
+            {"value": "Only_WCDMA", "label": "3G only"},
+        ],
+        "lte_bands": [1, 2, 3, 4, 5, 7, 8, 18, 19, 20, 26, 28, 29, 32, 34, 38, 39, 40, 41, 42, 43, 48, 66, 71],
+        "nr_sa_bands": [1, 2, 3, 5, 7, 8, 18, 20, 26, 28, 29, 38, 40, 41, 48, 66, 71, 75, 77, 78, 79],
+        "nr_nsa_band_lock_supported": False,
+    },
+    "/api/sms/capabilities": lambda: {
+        "available": True, "ready": True, "object": "mock_wms", "storage": "native",
     },
     "/api/router/dns": lambda: STATE["dns"],
     "/api/router/lan": lambda: STATE["lan"],
     "/api/router/apn/mode": lambda: STATE["apn_mode"],
     "/api/router/apn/profiles": apn_profiles,
     "/api/sim/info": lambda: {
-        "sim_iccid": "89610112345678901234", "sim_imsi": "505011234567890",
+        "sim_iccid": "", "sim_imsi": "",
         "sim_states": "SIM_READY", "mdm_mcc": "505", "mdm_mnc": "01",
     },
-    "/api/sim/imei": lambda: {"imei": "351234567890123"},
+    "/api/sim/imei": lambda: {"imei": ""},
     "/api/ttl/status": lambda: STATE["ttl"],
     "/api/system/top": system_top,
     "/api/logger/signal/status": lambda: {


### PR DESCRIPTION
## Summary

- harden optional-service stopping and make the AT console exactly read-only
- correct LAN/DHCP, network-mode, LTE/NR band, Wi-Fi 7 EHT, sensor and manual APN contracts
- repair SMS through the firmware WMS UBUS interface without direct database access
- add a separate emulator-only WMS object and guarded mutation-and-restore regression suite
- document that these optimisations were validated against the stock-firmware QEMU environment
- remove synthetic device identifiers from the mock and add a tracked device-secret audit

## Why

Several dashboard payloads and choices had drifted from the MU5250 firmware
contracts. Safety-sensitive operations also needed stronger fail-closed
boundaries given the documented history of device damage. The changes derive
values and supported choices from firmware behavior, reject unknown inputs
before UBUS calls, and avoid partitions, boot hooks, daemon-conf service
mutation, live `usb_op`, unrestricted AT, destructive power paths and direct
SMS database writes.

## User impact

LAN/DHCP, network modes, band selection, Wi-Fi 7 bandwidth, sensor
availability, manual APNs and SMS now match the emulated firmware behavior.
Unsupported or unavailable operations are shown or returned explicitly instead
of silently sending incorrect payloads or displaying zeros.

## Validation

- `cargo test`: 31 passed
- dashboard `npm run lint` and production build: passed
- agent/dashboard/mock API contract: passed (62 routes, 57 paths)
- device-secret audit: passed; no hard-coded IMEI/IMSI/ICCID, ZTE backup suffix, private key or recognized credential token
- shell and Python syntax checks: passed
- `git diff --check`: passed
- guarded QEMU suite: all 9 passed, including restoration of LAN, Wi-Fi, APN and SMS state

QEMU runs the stock firmware userland and real UBUS services where hardware
permits. Physical radio, sensor and modem behavior still requires final device
testing; this limitation is documented in `docs/EMULATION.md`.
