### PR TITLE
Fix v2.2 desktop release packaging

### DIFF
--- a/.github/workflows/installer.yml
+++ b/.github/workflows/installer.yml
@@ -116,21 +116,18 @@ jobs:
           tagName: ${{ github.ref_name }}
           args: ${{ matrix.args }}
 
-      - name: Build macOS app bundle for ZIP
-        if: runner.os == 'macOS'
-        working-directory: installer
-        env:
-          APPLE_ID: ${{ secrets.APPLE_ID }}
-          APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
-          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
-        run: npm run tauri build -- --target ${{ matrix.target }} --bundles app
-
       - name: Package macOS app bundle as ZIP
         if: runner.os == 'macOS'
         shell: bash
         run: |
-          APP_PATH="$(find target -type d -name 'Open U60 Pro Installer.app' -print -quit)"
-          test -n "$APP_PATH"
+          DMG_PATH="$(find target -type f -name '*.dmg' -print -quit)"
+          test -n "$DMG_PATH"
+          MOUNT_POINT="$RUNNER_TEMP/open-u60-pro-dmg-${{ matrix.archive_arch }}"
+          mkdir -p "$MOUNT_POINT"
+          hdiutil attach -nobrowse -readonly -mountpoint "$MOUNT_POINT" "$DMG_PATH"
+          trap 'hdiutil detach "$MOUNT_POINT"' EXIT
+          APP_PATH="$MOUNT_POINT/Open U60 Pro Installer.app"
+          test -d "$APP_PATH"
           codesign --verify --deep --strict "$APP_PATH"
           VERSION="$(node -p "require('./installer/package.json').version")"
           ARCHIVE="Open-U60-Pro-Installer_${VERSION}_${{ matrix.archive_arch }}.app.zip"
@@ -141,6 +138,8 @@ jobs:
           codesign --verify --deep --strict "$VERIFY_DIR/Open U60 Pro Installer.app"
           shasum -a 256 "$ARCHIVE"
           echo "MACOS_ZIP=$ARCHIVE" >> "$GITHUB_ENV"
+          hdiutil detach "$MOUNT_POINT"
+          trap - EXIT
 
       - name: Upload manually triggered package
         if: github.event_name == 'workflow_dispatch'

--- a/installer/src-tauri/tauri.conf.json
+++ b/installer/src-tauri/tauri.conf.json
@@ -31,6 +31,13 @@
     "category": "Utility",
     "shortDescription": "Install and maintain Open U60 Pro",
     "longDescription": "Guided installer for the Open U60 Pro agent, SSH access and dashboard on the ZTE MU5250.",
+    "icon": [
+      "icons/32x32.png",
+      "icons/128x128.png",
+      "icons/128x128@2x.png",
+      "icons/icon.icns",
+      "icons/icon.ico"
+    ],
     "resources": {
       "../assets/platform-tools/": "platform-tools/"
     },


### PR DESCRIPTION
## Summary

- package each macOS `.app.zip` from the already-built DMG, ensuring the ZIP and DMG contain the same signed application while avoiding a redundant Tauri rebuild
- explicitly configure the cross-platform Tauri icon set so WiX can find the Windows `.ico`

## Root causes found by pre-release Actions run

- the second macOS app-only build treated empty Apple secret variables as incomplete notarization credentials
- the Windows MSI bundler could not infer an ICO without an explicit `bundle.icon` list

## Validation

- workflow YAML and Tauri JSON parse successfully
- installer TypeScript check passes
- local Tauri app bundle builds with the configured icon list
- a local v2.2 DMG was mounted, its app strictly code-signature verified, archived with `ditto`, extracted, and strictly verified again

The v2.2 tag has not been created; the cross-platform workflow will be rerun after merge.
